### PR TITLE
[RFC] Add DoubleFileExtensionFilter

### DIFF
--- a/src/main/java/nl/tudelft/dnainator/ui/actions/OpenAction.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/actions/OpenAction.java
@@ -9,11 +9,11 @@ import java.util.concurrent.ExecutionException;
 import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
 import javax.swing.KeyStroke;
-import javax.swing.filechooser.FileNameExtensionFilter;
 
 import nl.tudelft.dnainator.ui.DNAViewer;
 import nl.tudelft.dnainator.ui.Window;
 import nl.tudelft.dnainator.util.FileLoader;
+import nl.tudelft.dnainator.util.DoubleFileExtensionFilter;
 
 /**
  * A Swing Action to open the "Open File" dialog.
@@ -45,7 +45,7 @@ public class OpenAction extends AbstractAction {
 	@Override
 	public void actionPerformed(ActionEvent e) {
 		JFileChooser chooser = new JFileChooser(lastDirectory);
-		chooser.setFileFilter(new FileNameExtensionFilter("Graphs", "graph"));
+		chooser.setFileFilter(new DoubleFileExtensionFilter("Graphs", "node.graph"));
 
 		if (chooser.showOpenDialog(parent) == JFileChooser.APPROVE_OPTION) {
 			File nodeFile = chooser.getSelectedFile();

--- a/src/main/java/nl/tudelft/dnainator/util/DoubleFileExtensionFilter.java
+++ b/src/main/java/nl/tudelft/dnainator/util/DoubleFileExtensionFilter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package nl.tudelft.dnainator.util;
+
+import java.io.File;
+import java.util.Locale;
+
+import javax.swing.filechooser.FileFilter;
+
+/**
+ * A re-implementation of {@code FileNameExtensionFilter} that filters
+ * using a specified set of double extensions. A double extension is an
+ * extension from an extension, e.g. tar.gz. This double extension for a
+ * file is the portion of the file name after the second last ".".
+ * Files whose name does not contain any or exactly one "." have no double
+ * file name extension. File name extension comparisons are case insensitive.
+ * <p>
+ * The following example creates a
+ * {@code DoubleFileExtensionFilter} that will show {@code tar.gz} files:
+ * <pre>
+ * FileFilter filter = new DoubleFileExtensionFilter("TAR gz file", "tar.gz");
+ * JFileChooser fileChooser = ...;
+ * fileChooser.addChoosableFileFilter(filter);
+ * </pre>
+ *
+ * @see FileFilter
+ * @see javax.swing.filechooser.FileNameExtensionFilter;
+ * @see javax.swing.JFileChooser#setFileFilter
+ * @see javax.swing.JFileChooser#addChoosableFileFilter
+ * @see javax.swing.JFileChooser#getFileFilter
+ */
+public final class DoubleFileExtensionFilter extends FileFilter {
+	private final String description;
+	private final String[] extensions;
+	private final String[] lowerCaseExtensions;
+
+	/**
+	 * Creates a {@code DoubleFileExtensionFilter} with the specified
+	 * description and double file name extensions. The returned {@code
+	 * DoubleFileExtensionFilter} will accept all directories and any
+	 * file with a file name extension contained in {@code extensions}.
+	 *
+	 * @param description textual description for the filter, may be
+	 *			  {@code null}
+	 * @param extensions the accepted double file name extensions
+	 * @throws IllegalArgumentException if extensions is {@code null}, empty,
+	 *         contains {@code null}, contains an empty string or is a single
+	 *         extension.
+	 * @see #accept
+	 */
+	public DoubleFileExtensionFilter(String description, String... extensions) {
+		if (extensions == null || extensions.length == 0) {
+			throw new IllegalArgumentException(
+				"Extensions must be non-null and not empty");
+		}
+		this.description = description;
+		this.extensions = new String[extensions.length];
+		this.lowerCaseExtensions = new String[extensions.length];
+		for (int i = 0; i < extensions.length; i++) {
+			if (extensions[i] == null || extensions[i].length() == 0
+					|| extensions[i].lastIndexOf('.') == -1) {
+			throw new IllegalArgumentException(
+				"Each extension must be non-null, not empty and double");
+			}
+			this.extensions[i] = extensions[i];
+			this.lowerCaseExtensions[i] = extensions[i].toLowerCase(Locale.ENGLISH);
+		}
+	}
+
+	/**
+	 * Tests the specified file, returning true if the file is
+	 * accepted, false otherwise. True is returned if the extension
+	 * matches one of the double file name extensions of this {@code
+	 * FileFilter}, or the file is a directory.
+	 *
+	 * @param f the {@code File} to test
+	 * @return true if the file is to be accepted, false otherwise
+	 */
+	public boolean accept(File f) {
+		if (f == null) {
+			return false;
+		} else if (f.isDirectory()) {
+			return true;
+		}
+
+		// NOTE: we tested implementations using Maps, binary search
+		// on a sorted list and this implementation. All implementations
+		// provided roughly the same speed, most likely because of
+		// overhead associated with java.io.File. Therefore we've stuck
+		// with the simple lightweight approach.
+		String fileName = f.getName();
+		int i = fileName.lastIndexOf('.');
+		if (i > 0 && i < fileName.length() - 1) {
+			int j = fileName.substring(0, i).lastIndexOf('.');
+			if (j > 0 && j < fileName.length() - 1) {
+				String desiredExtension = fileName.substring(j + 1).
+						toLowerCase(Locale.ENGLISH);
+				for (String extension : lowerCaseExtensions) {
+					if (desiredExtension.equals(extension)) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * The description of this filter. For example: "TAR gz file."
+	 *
+	 * @return the description of this filter
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * @return The set of double file name extensions files are tested against
+	 */
+	public String[] getExtensions() {
+		String[] result = new String[extensions.length];
+		System.arraycopy(extensions, 0, result, 0, extensions.length);
+		return result;
+	}
+}

--- a/src/test/java/nl/tudelft/dnainator/util/DoubleFileExtensionFilterText.java
+++ b/src/test/java/nl/tudelft/dnainator/util/DoubleFileExtensionFilterText.java
@@ -1,0 +1,166 @@
+package nl.tudelft.dnainator.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test case for {@link nl.tudelft.dnainator.util.DoubleFileExtensionFilter}.
+ */
+public class DoubleFileExtensionFilterText {
+	private DoubleFileExtensionFilter subject;
+
+	/**
+	 * Initializes test environment.
+	 */
+	@Before
+	public void setup() {
+		subject = new DoubleFileExtensionFilter("Graphs", "node.graph");
+	}
+
+	/**
+	 * Tests if the constructor throws an exception when
+	 * no extensions are passed.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorNoExt() {
+		new DoubleFileExtensionFilter("Graphs", new String[0]);
+	}
+
+	/**
+	 * Tests if the constructor throws an exception when
+	 * a null-extension is passed.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorNullExt() {
+		String[] extensions = { "node.graph", null, "edge.graph" };
+		new DoubleFileExtensionFilter("Graph", extensions);
+	}
+
+	/**
+	 * Tests if the constructor throws an exception when
+	 * an empty extension is passed.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorEmptyExt() {
+		String[] extensions = { "node.graph", "", "edge.graph" };
+		new DoubleFileExtensionFilter("Graph", extensions);
+	}
+
+	/**
+	 * Tests if the constructor throws an exception when
+	 * a single extension is passed.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorSingleExt() {
+		String[] extensions = { "node.graph", "graph", "edge.graph" };
+		new DoubleFileExtensionFilter("Graph", extensions);
+	}
+
+	/**
+	 * Tests if the file filter accepts files with
+	 * a double extension.
+	 */
+	@Test
+	public void testAccept() {
+		File f;
+		try {
+			f = File.createTempFile("10_strains", ".node.graph");
+			assertTrue(subject.accept(f));
+			f.delete();
+		} catch (IOException e) {
+			fail(e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests if the file filter denies files with
+	 * an incorrect double extension.
+	 */
+	@Test
+	public void testDenyIncorrect() {
+		File f;
+		try {
+			f = File.createTempFile("10_strains", ".tar.gz");
+			assertFalse(subject.accept(f));
+			f.delete();
+		} catch (IOException e) {
+			fail(e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests if the file filter denies files with
+	 * a single extension.
+	 */
+	@Test
+	public void testDenySingle() {
+		File f;
+		try {
+			f = File.createTempFile("10_strains", ".txt");
+			assertFalse(subject.accept(f));
+			f.delete();
+		} catch (IOException e) {
+			fail(e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests if the file filter denies files with a
+	 * partly correct extension.
+	 */
+	@Test
+	public void testDenyPartOne() {
+		File f;
+		try {
+			f = File.createTempFile("10_strains", ".node.gz");
+			assertFalse(subject.accept(f));
+			f.delete();
+		} catch (IOException e) {
+			fail(e.getMessage());
+		}		
+	}
+
+	/**
+	 * Tests if the file filter denies files with a
+	 * partly correct extension.
+	 */
+	@Test
+	public void testDenyPartTwo() {
+		File f;
+		try {
+			f = File.createTempFile("10_strains", ".edge.graph");
+			assertFalse(subject.accept(f));
+			f.delete();
+		} catch (IOException e) {
+			fail(e.getMessage());
+		}		
+	}
+
+	/**
+	 * Tests getDescription().
+	 */
+	@Test
+	public void testGetDescription() {
+		assertEquals("Graphs", subject.getDescription());
+	}
+
+	/**
+	 * Tests getExtensions().
+	 */
+	@Test
+	public void testGetExtensions() {
+		String[] expected = { "node.graph" };
+		String[] extensions = subject.getExtensions();
+		for (int i = 0; i < expected.length; i++) {
+			assertEquals(expected[i], extensions[i]);
+		}
+	}
+}


### PR DESCRIPTION
The standard FileNameExtensionFilter is not sufficient for our needs, as it filters
only on the last '.' of the file name while our file extensions contain two '.'. We can
work around this issue by filtering on ".graph", but then we would face the issue of
determining which file the user openend first (node or edge). To prevent all this,
here is an implementation of the `FileFilter` interface that filters on double file extensions.