### PR TITLE
[RDY] Throw InvalidEdgeFormatExceptions. Fixes #32

### DIFF
--- a/src/main/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParser.java
+++ b/src/main/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParser.java
@@ -107,6 +107,7 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 	private String parseDest() throws IOException, InvalidEdgeFormatException {
 		StringBuilder dest = new StringBuilder(ID_LENGTH_GUESS);
 		int point = eatSpaces(br.read());
+		boolean destParsed = false;
 		char next;
 
 		parseLoop: while (point != -1) {
@@ -115,9 +116,13 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 			case '\n': case '\r':
 				break parseLoop;
 			case ' ':
+				destParsed = true;
 				point = eatSpaces(br.read());
 				break;
 			default:
+				if (destParsed) {
+					throw new InvalidEdgeFormatException("Found extra node");
+				}
 				dest.append(next);
 				point = br.read();
 			}

--- a/src/main/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParser.java
+++ b/src/main/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParser.java
@@ -5,7 +5,10 @@ import nl.tudelft.dnainator.parser.exceptions.InvalidEdgeFormatException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * An implementation for parsing an edge file input stream.
@@ -14,6 +17,11 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 	private Edge<String> current;
 	private boolean needParse = true; // Whether we have to parse a new line or not.
 	private static final int ID_LENGTH_GUESS = 8;
+	private static final Set<Character> WHITESPACE = new HashSet<>();
+
+	static {
+		Collections.addAll(WHITESPACE, '\n', '\r', '\t', ' ');
+	}
 
 	/**
 	 * Constructs a {@link DefaultEdgeParser}, which reads from
@@ -44,7 +52,7 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 	 * @throws IOException Thrown when the reader fails.
 	 */
 	private Edge<String> parse() throws IOException, InvalidEdgeFormatException {
-		int first = eatSpaces(br.read());
+		int first = eatWhitespace(br.read());
 		if (first == -1) {
 			return null;
 		}
@@ -78,6 +86,13 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 	 */
 	private int eatSpaces(int next) throws IOException {
 		while ((char) next == ' ') {
+			next = br.read();
+		}
+		return next;
+	}
+
+	private int eatWhitespace(int next) throws IOException {
+		while (WHITESPACE.contains((char) next)) {
 			next = br.read();
 		}
 		return next;

--- a/src/main/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParser.java
+++ b/src/main/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParser.java
@@ -44,7 +44,7 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 	 * @throws IOException Thrown when the reader fails.
 	 */
 	private Edge<String> parse() throws IOException, InvalidEdgeFormatException {
-		int first = br.read();
+		int first = eatSpaces(br.read());
 		if (first == -1) {
 			return null;
 		}
@@ -70,6 +70,12 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 		return source.toString();
 	}
 
+	/**
+	 * Eats spaces until a non-space character is found.
+	 * @param next the next character to test for space.
+	 * @return the non-space character (or -1 if end is reached).
+	 * @throws IOException if something went wrong I/O-wise.
+	 */
 	private int eatSpaces(int next) throws IOException {
 		while ((char) next == ' ') {
 			next = br.read();
@@ -88,11 +94,11 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 		int point = eatSpaces(br.read());
 		char next;
 
-		while (point != -1) {
+		parseLoop: while (point != -1) {
 			next = (char) point;
 			switch (next) {
 			case '\n': case '\r':
-				return dest.toString();
+				break parseLoop;
 			case ' ':
 				point = eatSpaces(br.read());
 				break;
@@ -102,6 +108,9 @@ public class DefaultEdgeParser extends BufferedEdgeParser {
 			}
 		}
 
+		if (dest.length() == 0) {
+			throw new InvalidEdgeFormatException("Missing destination node");
+		}
 		return dest.toString();
 	}
 

--- a/src/test/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParserTest.java
+++ b/src/test/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParserTest.java
@@ -163,4 +163,50 @@ public class DefaultEdgeParserTest {
 			fail("Shouldn't happen.");
 		}
 	}
+
+	/**
+	 * Test for a space-filled line in the middle.
+	 */
+	@Test
+	public void testParseEdgesBlankLineInMiddle() {
+		BufferedReader in = toBufferedReader(String.join("\n",
+				"1 2",
+				"    ",
+				"3 4"
+				));
+		EdgeParser ep = new DefaultEdgeParser(in);
+		try {
+			assertTrue(ep.hasNext());
+			Edge<String> next = ep.next();
+			assertEdgeEquals(new Edge<>("1", "2"), next);
+			assertTrue(ep.hasNext());
+			next = ep.next();
+			assertEdgeEquals(new Edge<>("3", "4"), next);
+		} catch (IOException | InvalidEdgeFormatException e) {
+			fail("Shouldn't happen.");
+		}
+	}
+
+	/**
+	 * Test for a empty line in the middle.
+	 */
+	@Test
+	public void testParseEdgesEmptyLineInMiddle() {
+		BufferedReader in = toBufferedReader(String.join("\n",
+				"1 2",
+				"",
+				"3 4"
+				));
+		EdgeParser ep = new DefaultEdgeParser(in);
+		try {
+			assertTrue(ep.hasNext());
+			Edge<String> next = ep.next();
+			assertEdgeEquals(new Edge<>("1", "2"), next);
+			assertTrue(ep.hasNext());
+			next = ep.next();
+			assertEdgeEquals(new Edge<>("3", "4"), next);
+		} catch (IOException | InvalidEdgeFormatException e) {
+			fail("Shouldn't happen.");
+		}
+	}
 }

--- a/src/test/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParserTest.java
+++ b/src/test/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParserTest.java
@@ -102,4 +102,65 @@ public class DefaultEdgeParserTest {
 		}
 	}
 
+	/**
+	 * Tests exception throwing.
+	 * @throws InvalidEdgeFormatException on test success.
+	 */
+	@Test(expected = InvalidEdgeFormatException.class)
+	public void testParseEdgesMissingDest() throws InvalidEdgeFormatException {
+		BufferedReader in = toBufferedReader(String.join("\n",
+				"1 2",
+				"3 ",
+				"4 5"
+				));
+		EdgeParser ep = new DefaultEdgeParser(in);
+		try {
+			assertTrue(ep.hasNext());
+			Edge<String> next = ep.next();
+			assertEdgeEquals(new Edge<>("1", "2"), next);
+			next = ep.next();
+		} catch (IOException e) {
+			fail("Shouldn't happen.");
+		}
+	}
+
+	/**
+	 * Test for a empty line.
+	 */
+	@Test
+	public void testParseEdgesEmptyLine() {
+		BufferedReader in = toBufferedReader(String.join("\n",
+				"1 2",
+				""
+				));
+		EdgeParser ep = new DefaultEdgeParser(in);
+		try {
+			assertTrue(ep.hasNext());
+			Edge<String> next = ep.next();
+			assertEdgeEquals(new Edge<>("1", "2"), next);
+			assertFalse(ep.hasNext());
+		} catch (IOException | InvalidEdgeFormatException e) {
+			fail("Shouldn't happen.");
+		}
+	}
+
+	/**
+	 * Test for a space-filled line.
+	 */
+	@Test
+	public void testParseEdgesBlankLine() {
+		BufferedReader in = toBufferedReader(String.join("\n",
+				"1 2",
+				"    "
+				));
+		EdgeParser ep = new DefaultEdgeParser(in);
+		try {
+			assertTrue(ep.hasNext());
+			Edge<String> next = ep.next();
+			assertEdgeEquals(new Edge<>("1", "2"), next);
+			assertFalse(ep.hasNext());
+		} catch (IOException | InvalidEdgeFormatException e) {
+			fail("Shouldn't happen.");
+		}
+	}
 }

--- a/src/test/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParserTest.java
+++ b/src/test/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParserTest.java
@@ -118,11 +118,34 @@ public class DefaultEdgeParserTest {
 			assertTrue(ep.hasNext());
 			Edge<String> next = ep.next();
 			assertEdgeEquals(new Edge<>("1", "2"), next);
-			next = ep.next();
+			ep.next();
 		} catch (IOException e) {
 			fail("Shouldn't happen.");
 		}
 	}
+
+	/**
+	 * Tests exception throwing.
+	 * @throws InvalidEdgeFormatException on test success.
+	 */
+	@Test(expected = InvalidEdgeFormatException.class)
+	public void testParseEdgesExtraNode() throws InvalidEdgeFormatException {
+		BufferedReader in = toBufferedReader(String.join("\n",
+				"1 2",
+				"3 4 5",
+				"6 7"
+				));
+		EdgeParser ep = new DefaultEdgeParser(in);
+		try {
+			assertTrue(ep.hasNext());
+			Edge<String> next = ep.next();
+			assertEdgeEquals(new Edge<>("1", "2"), next);
+			ep.next();
+		} catch (IOException e) {
+			fail("Shouldn't happen.");
+		}
+	}
+
 
 	/**
 	 * Test for a empty line.

--- a/src/test/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParserTest.java
+++ b/src/test/java/nl/tudelft/dnainator/parser/buffered/DefaultEdgeParserTest.java
@@ -39,6 +39,21 @@ public class DefaultEdgeParserTest {
 	}
 
 	/**
+	 * Tests an empty input.
+	 * @throws InvalidEdgeFormatException means that the test succeeded.
+	 */
+	@Test(expected = InvalidEdgeFormatException.class)
+	public void testParseOneCharacter() throws InvalidEdgeFormatException {
+		BufferedReader in = toBufferedReader("a");
+		EdgeParser ep = new DefaultEdgeParser(in);
+		try {
+			ep.next();
+		} catch (IOException e) {
+			fail("Shouldn't happen.");
+		}
+	}
+
+	/**
 	 * Tests a good weather situation, where the input is in
 	 * correct format.
 	 */
@@ -145,7 +160,6 @@ public class DefaultEdgeParserTest {
 			fail("Shouldn't happen.");
 		}
 	}
-
 
 	/**
 	 * Test for a empty line.


### PR DESCRIPTION
Throws an InvalidEdgeFormatException on lines with more or less than two node identifiers.

Also fixes a bug where a line with only spaces looped infinitely.
Blank or empty lines are silently ignored.

Fixes #32