### PR TITLE
[RDY] Query description framework rewrite.

### DIFF
--- a/src/main/java/nl/tudelft/dnainator/graph/Graph.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/Graph.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.core.impl.Edge;
+import nl.tudelft.dnainator.graph.query.GraphQueryDescription;
 
 /**
  * Interface for backend agnostic interaction with a graph.

--- a/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
@@ -324,7 +324,7 @@ public final class Neo4jGraph implements Graph {
 	}
 
 	@Override
-	public List<SequenceNode> queryNodes(GraphQueryDescription q) {
-		return new Neo4jQuery(q).execute(service);
+	public List<SequenceNode> queryNodes(GraphQueryDescription qd) {
+		return Neo4jQuery.of(qd).execute(service);
 	}
 }

--- a/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
@@ -10,7 +10,7 @@ import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.core.impl.Edge;
 import nl.tudelft.dnainator.core.impl.SequenceNodeImpl;
 import nl.tudelft.dnainator.graph.Graph;
-import nl.tudelft.dnainator.graph.GraphQueryDescription;
+import nl.tudelft.dnainator.graph.query.GraphQueryDescription;
 import nl.tudelft.dnainator.parser.EdgeParser;
 import nl.tudelft.dnainator.parser.NodeParser;
 import nl.tudelft.dnainator.parser.exceptions.ParseException;

--- a/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
@@ -27,18 +27,13 @@ import nl.tudelft.dnainator.graph.query.SourcesFilter;
  * A useful class for creating and executing a query on a Neo4j
  * database using a {@link GraphQueryDescription}.
  */
-public class Neo4jQuery implements GraphQuery {
+public final class Neo4jQuery implements GraphQuery {
 	private boolean multipleConditions;
 	private Map<String, Object> parameters;
 	private StringBuilder sb;
 	private Predicate<SequenceNode> p;
 
-	/**
-	 * Create a new query suitable for Neo4j from the given description.
-	 * @param qd the query description to use for constructing the query.
-	 */
-	public Neo4jQuery(GraphQueryDescription qd) {
-		compile(qd);
+	private Neo4jQuery() {
 	}
 
 	private void addCondition(String c) {
@@ -116,5 +111,17 @@ public class Neo4jQuery implements GraphQuery {
 	public void compile(RankEnd end) {
 		addCondition("n.dist < {to}\n");
 		parameters.put("to", end.getEnd());
+	}
+
+	/**
+	 * Construct a {@link Neo4jQuery} based on the given
+	 * {@link GraphQueryDescription}.
+	 * @param qd the description of the query.
+	 * @return the compiled query.
+	 */
+	public static Neo4jQuery of(GraphQueryDescription qd) {
+		Neo4jQuery q = new Neo4jQuery();
+		q.compile(qd);
+		return q;
 	}
 }

--- a/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
@@ -14,7 +14,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 
 import nl.tudelft.dnainator.core.SequenceNode;
-import nl.tudelft.dnainator.graph.GraphQueryDescription;
+import nl.tudelft.dnainator.graph.query.GraphQueryDescription;
 
 /**
  * A useful class for creating and executing a query on a Neo4j

--- a/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
@@ -1,5 +1,6 @@
 package nl.tudelft.dnainator.graph.impl;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,16 +80,24 @@ public class Neo4jQuery implements GraphQuery {
 		qd.accept(this);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void compile(IDsFilter ids) {
 		addCondition("n.id IN {ids}\n");
-		parameters.put("ids", ids.getIds());
+		parameters.merge("ids", ids.getIds(), (left, right) -> {
+			((Collection<String>) left).addAll((Collection<String>) right);
+			return left;
+		});
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void compile(SourcesFilter sources) {
 		addCondition("n.source IN {sources}\n");
-		parameters.put("sources", sources.getSources());
+		parameters.merge("sources", sources.getSources(), (left, right) -> {
+			((Collection<String>) left).addAll((Collection<String>) right);
+			return left;
+		});
 	}
 
 	@Override

--- a/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
@@ -28,7 +28,7 @@ import nl.tudelft.dnainator.graph.query.SourcesFilter;
  * database using a {@link GraphQueryDescription}.
  */
 public class Neo4jQuery implements GraphQuery {
-	private boolean multipleConditions = false;
+	private boolean multipleConditions;
 	private Map<String, Object> parameters;
 	private StringBuilder sb;
 	private Predicate<SequenceNode> p;
@@ -38,9 +38,6 @@ public class Neo4jQuery implements GraphQuery {
 	 * @param qd the query description to use for constructing the query.
 	 */
 	public Neo4jQuery(GraphQueryDescription qd) {
-		this.sb = new StringBuilder("MATCH n\n");
-		this.parameters = new HashMap<>();
-		this.p = (sn) -> true;
 		compile(qd);
 	}
 
@@ -61,7 +58,6 @@ public class Neo4jQuery implements GraphQuery {
 	 * @return the query result.
 	 */
 	public List<SequenceNode> execute(GraphDatabaseService db) {
-		sb.append("RETURN n");
 		List<SequenceNode> result;
 		try (Transaction tx = db.beginTx()) {
 			Result r = db.execute(sb.toString(), parameters);
@@ -77,7 +73,12 @@ public class Neo4jQuery implements GraphQuery {
 
 	@Override
 	public void compile(GraphQueryDescription qd) {
+		this.multipleConditions = false;
+		this.parameters = new HashMap<>();
+		this.p = (sn) -> true;
+		this.sb = new StringBuilder("MATCH n\n");
 		qd.accept(this);
+		sb.append("RETURN n");
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/nl/tudelft/dnainator/graph/query/GraphQuery.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/GraphQuery.java
@@ -1,17 +1,42 @@
 package nl.tudelft.dnainator.graph.query;
 
+/**
+ * Interface for classes which can compile a
+ * {@link GraphQueryDescription} and {@link QueryElement}s.
+ * This is implemented according to the visitor pattern. The compile
+ * methods are the "visit" methods in the visitor pattern.
+ */
 public interface GraphQuery {
 
+	/**
+	 * Compiles the given {@link GraphQueryDescription}.
+	 * @param qd The description for the query to be compiled.
+	 */
 	void compile(GraphQueryDescription qd);
 
-	void compile(IDsFilter iDsFilter);
+	/**
+	 * @param ids The filter on node IDs to be compiled.
+	 */
+	void compile(IDsFilter ids);
 
-	void compile(SourcesFilter sourcesFilter);
+	/**
+	 * @param sources The filter on sources to be compiled.
+	 */
+	void compile(SourcesFilter sources);
 
-	void compile(PredicateFilter predicateFilter);
+	/**
+	 * @param p The predicate to be compiled.
+	 */
+	void compile(PredicateFilter p);
 
-	void compile(RankStart rankStart);
+	/**
+	 * @param start The start rank from where to start searching.
+	 */
+	void compile(RankStart start);
 
-	void compile(RankEnd rankEnd);
+	/**
+	 * @param end The end rank where to stop searching.
+	 */
+	void compile(RankEnd end);
 
 }

--- a/src/main/java/nl/tudelft/dnainator/graph/query/GraphQuery.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/GraphQuery.java
@@ -1,0 +1,17 @@
+package nl.tudelft.dnainator.graph.query;
+
+public interface GraphQuery {
+
+	void compile(GraphQueryDescription qd);
+
+	void compile(IDsFilter iDsFilter);
+
+	void compile(SourcesFilter sourcesFilter);
+
+	void compile(PredicateFilter predicateFilter);
+
+	void compile(RankStart rankStart);
+
+	void compile(RankEnd rankEnd);
+
+}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/GraphQueryDescription.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/GraphQueryDescription.java
@@ -1,4 +1,4 @@
-package nl.tudelft.dnainator.graph;
+package nl.tudelft.dnainator.graph.query;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/nl/tudelft/dnainator/graph/query/GraphQueryDescription.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/GraphQueryDescription.java
@@ -11,13 +11,7 @@ import nl.tudelft.dnainator.core.SequenceNode;
  * A description of a query and its parameters.
  */
 public class GraphQueryDescription {
-	private Collection<String> idStrings;
-	private Collection<String> sourceStrings;
-	private Predicate<SequenceNode> filter;
-	private boolean queryFrom = false;
-	private int from = 0;
-	private boolean queryTo = false;
-	private int to = Integer.MAX_VALUE;
+	private Collection<QueryElement> elems = new ArrayList<>();
 
 	/**
 	 * Query for the given id.
@@ -34,26 +28,8 @@ public class GraphQueryDescription {
 	 * @return this
 	 */
 	public GraphQueryDescription haveIds(Collection<String> ids) {
-		if (idStrings == null) {
-			idStrings = new ArrayList<>(ids);
-			return this;
-		}
-		idStrings.addAll(ids);
+		elems.add(new IDsFilter(ids));
 		return this;
-	}
-
-	/**
-	 * @return Whether the query should query for ids.
-	 */
-	public boolean shouldQueryIds() {
-		return idStrings != null;
-	}
-
-	/**
-	 * @return The ids to query for.
-	 */
-	public Collection<String> getIds() {
-		return idStrings;
 	}
 
 	/**
@@ -71,26 +47,8 @@ public class GraphQueryDescription {
 	 * @return this
 	 */
 	public GraphQueryDescription containsSources(Collection<String> sources) {
-		if (sourceStrings == null) {
-			sourceStrings = new ArrayList<>(sources);
-			return this;
-		}
-		sourceStrings.addAll(sources);
+		elems.add(new SourcesFilter(sources));
 		return this;
-	}
-
-	/**
-	 * @return Whether the query should query for sources.
-	 */
-	public boolean shouldQuerySources() {
-		return sourceStrings != null;
-	}
-
-	/**
-	 * @return The source parameters.
-	 */
-	public Collection<String> getSources() {
-		return sourceStrings;
 	}
 
 	/**
@@ -99,22 +57,8 @@ public class GraphQueryDescription {
 	 * @return this
 	 */
 	public GraphQueryDescription filter(Predicate<SequenceNode> p) {
-		filter = p;
+		elems.add(new PredicateFilter(p));
 		return this;
-	}
-
-	/**
-	 * @return Whether the result should be filtered.
-	 */
-	public boolean shouldFilter() {
-		return filter != null;
-	}
-
-	/**
-	 * @return The filter predicate.
-	 */
-	public Predicate<SequenceNode> getFilter() {
-		return filter;
 	}
 
 	/**
@@ -123,23 +67,8 @@ public class GraphQueryDescription {
 	 * @return this
 	 */
 	public GraphQueryDescription fromRank(int start) {
-		from = start;
-		queryFrom = true;
+		elems.add(new RankStart(start));
 		return this;
-	}
-
-	/**
-	 * @return Whether the query should search from a rank.
-	 */
-	public boolean shouldQueryFrom() {
-		return queryFrom;
-	}
-
-	/**
-	 * @return The rank to search from (inclusive).
-	 */
-	public int getFrom() {
-		return from;
 	}
 
 	/**
@@ -148,22 +77,13 @@ public class GraphQueryDescription {
 	 * @return this
 	 */
 	public GraphQueryDescription toRank(int end) {
-		to = end;
-		queryTo = true;
+		elems.add(new RankEnd(end));
 		return this;
 	}
 
-	/**
-	 * @return Whether the query should search towards a rank.
-	 */
-	public boolean shouldQueryTo() {
-		return queryTo;
-	}
-
-	/**
-	 * @return The rank to search towards (exclusive).
-	 */
-	public int getTo() {
-		return to;
+	public void accept(GraphQuery q) {
+		for (QueryElement e : elems) {
+			e.accept(q);
+		}
 	}
 }

--- a/src/main/java/nl/tudelft/dnainator/graph/query/GraphQueryDescription.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/GraphQueryDescription.java
@@ -81,6 +81,11 @@ public class GraphQueryDescription {
 		return this;
 	}
 
+	/**
+	 * Accepts the {@link GraphQuery} as a visitor, to compile the
+	 * query.
+	 * @param q The query to compile according to this query description.
+	 */
 	public void accept(GraphQuery q) {
 		for (QueryElement e : elems) {
 			e.accept(q);

--- a/src/main/java/nl/tudelft/dnainator/graph/query/GraphQueryDescription.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/GraphQueryDescription.java
@@ -19,7 +19,7 @@ public class GraphQueryDescription {
 	 * @return this
 	 */
 	public GraphQueryDescription hasId(String id) {
-		return haveIds(Collections.singletonList(id));
+		return haveIds(new ArrayList<>(Collections.singletonList(id)));
 	}
 
 	/**
@@ -38,7 +38,7 @@ public class GraphQueryDescription {
 	 * @return this
 	 */
 	public GraphQueryDescription containsSource(String source) {
-		return containsSources(Collections.singletonList(source));
+		return containsSources(new ArrayList<>(Collections.singletonList(source)));
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/dnainator/graph/query/IDsFilter.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/IDsFilter.java
@@ -2,13 +2,23 @@ package nl.tudelft.dnainator.graph.query;
 
 import java.util.Collection;
 
+/**
+ * Describes a filter on IDs.
+ */
 public class IDsFilter implements QueryElement {
 	private Collection<String> ids;
 
+	/**
+	 * Constructs a new filter.
+	 * @param ids The String IDs to filter on.
+	 */
 	public IDsFilter(Collection<String> ids) {
 		this.ids = ids;
 	}
 
+	/**
+	 * @return the String IDs to filter on.
+	 */
 	public Collection<String> getIds() {
 		return ids;
 	}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/IDsFilter.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/IDsFilter.java
@@ -1,0 +1,21 @@
+package nl.tudelft.dnainator.graph.query;
+
+import java.util.Collection;
+
+public class IDsFilter implements QueryElement {
+	private Collection<String> ids;
+
+	public IDsFilter(Collection<String> ids) {
+		this.ids = ids;
+	}
+
+	public Collection<String> getIds() {
+		return ids;
+	}
+
+	@Override
+	public void accept(GraphQuery q) {
+		q.compile(this);
+	}
+
+}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/PredicateFilter.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/PredicateFilter.java
@@ -4,13 +4,24 @@ import java.util.function.Predicate;
 
 import nl.tudelft.dnainator.core.SequenceNode;
 
+/**
+ * Describes a predicate which each result element of the query
+ * should satisfy.
+ */
 public class PredicateFilter implements QueryElement {
 	private Predicate<SequenceNode> filter;
 
+	/**
+	 * Constructs a new predicate filter.
+	 * @param p The predicate to use for filtering.
+	 */
 	public PredicateFilter(Predicate<SequenceNode> p) {
 		filter = p;
 	}
 
+	/**
+	 * @return the predicate to use for filtering.
+	 */
 	public Predicate<SequenceNode> getFilter() {
 		return filter;
 	}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/PredicateFilter.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/PredicateFilter.java
@@ -1,0 +1,23 @@
+package nl.tudelft.dnainator.graph.query;
+
+import java.util.function.Predicate;
+
+import nl.tudelft.dnainator.core.SequenceNode;
+
+public class PredicateFilter implements QueryElement {
+	private Predicate<SequenceNode> filter;
+
+	public PredicateFilter(Predicate<SequenceNode> p) {
+		filter = p;
+	}
+
+	public Predicate<SequenceNode> getFilter() {
+		return filter;
+	}
+
+	@Override
+	public void accept(GraphQuery q) {
+		q.compile(this);
+	}
+
+}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/QueryElement.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/QueryElement.java
@@ -1,0 +1,5 @@
+package nl.tudelft.dnainator.graph.query;
+
+public interface QueryElement {
+	void accept(GraphQuery q);
+}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/QueryElement.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/QueryElement.java
@@ -1,5 +1,13 @@
 package nl.tudelft.dnainator.graph.query;
 
+/**
+ * An element of a {@link GraphQueryDescription}.
+ */
 public interface QueryElement {
+	/**
+	 * Accept the given graph query as a visitor,
+	 * to compile this part of the query description.
+	 * @param q The query to compile.
+	 */
 	void accept(GraphQuery q);
 }

--- a/src/main/java/nl/tudelft/dnainator/graph/query/RankEnd.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/RankEnd.java
@@ -1,0 +1,19 @@
+package nl.tudelft.dnainator.graph.query;
+
+public class RankEnd implements QueryElement {
+	private int end;
+
+	public RankEnd(int end) {
+		this.end = end;
+	}
+
+	public int getEnd() {
+		return end;
+	}
+
+	@Override
+	public void accept(GraphQuery q) {
+		q.compile(this);
+	}
+
+}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/RankEnd.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/RankEnd.java
@@ -1,12 +1,23 @@
 package nl.tudelft.dnainator.graph.query;
 
+/**
+ * Describes the end rank to search towards.
+ * Forms a range together with {@link RankStart}.
+ */
 public class RankEnd implements QueryElement {
 	private int end;
 
+	/**
+	 * Constructs the end rank.
+	 * @param end The end rank number.
+	 */
 	public RankEnd(int end) {
 		this.end = end;
 	}
 
+	/**
+	 * @return the end rank number.
+	 */
 	public int getEnd() {
 		return end;
 	}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/RankStart.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/RankStart.java
@@ -1,12 +1,23 @@
 package nl.tudelft.dnainator.graph.query;
 
+/**
+ * Describes the start rank to search from.
+ * Forms a range together with {@link RankEnd}.
+ */
 public class RankStart implements QueryElement {
 	private int start;
 
+	/**
+	 * Constructs the start rank.
+	 * @param start The start rank number.
+	 */
 	public RankStart(int start) {
 		this.start = start;
 	}
 
+	/**
+	 * @return the start rank number.
+	 */
 	public int getStart() {
 		return start;
 	}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/RankStart.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/RankStart.java
@@ -1,0 +1,19 @@
+package nl.tudelft.dnainator.graph.query;
+
+public class RankStart implements QueryElement {
+	private int start;
+
+	public RankStart(int start) {
+		this.start = start;
+	}
+
+	public int getStart() {
+		return start;
+	}
+
+	@Override
+	public void accept(GraphQuery q) {
+		q.compile(this);
+	}
+
+}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/SourcesFilter.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/SourcesFilter.java
@@ -2,13 +2,23 @@ package nl.tudelft.dnainator.graph.query;
 
 import java.util.Collection;
 
+/**
+ * Describes a filter on sources.
+ */
 public class SourcesFilter implements QueryElement {
 	private Collection<String> sources;
 
+	/**
+	 * Constructs a new filter on sources.
+	 * @param sources The sources to filter on.
+	 */
 	public SourcesFilter(Collection<String> sources) {
 		this.sources = sources;
 	}
 
+	/**
+	 * @return the sources to filter on.
+	 */
 	public Collection<String> getSources() {
 		return sources;
 	}

--- a/src/main/java/nl/tudelft/dnainator/graph/query/SourcesFilter.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/query/SourcesFilter.java
@@ -1,0 +1,21 @@
+package nl.tudelft.dnainator.graph.query;
+
+import java.util.Collection;
+
+public class SourcesFilter implements QueryElement {
+	private Collection<String> sources;
+
+	public SourcesFilter(Collection<String> sources) {
+		this.sources = sources;
+	}
+
+	public Collection<String> getSources() {
+		return sources;
+	}
+
+	@Override
+	public void accept(GraphQuery q) {
+		q.compile(this);
+	}
+
+}

--- a/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
+++ b/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -134,21 +135,15 @@ public class Neo4jGraphTest {
 	public void testRanks() {
 		Set<String> rank0Expect = new HashSet<>();
 		Collections.addAll(rank0Expect, "7", "5", "3");
-		Set<String> rank0Actual = new HashSet<>();
-		db.getRank(0).forEach(e -> rank0Actual.add(e.getId()));
-		assertEquals(rank0Expect, rank0Actual);
+		assertUnorderedIDEquals(rank0Expect, db.getRank(0));
 
 		Set<String> rank1Expect = new HashSet<>();
 		Collections.addAll(rank1Expect, "11", "8");
-		Set<String> rank1Actual = new HashSet<>();
-		db.getRank(1).forEach(e -> rank1Actual.add(e.getId()));
-		assertEquals(rank1Expect, rank1Actual);
+		assertUnorderedIDEquals(rank1Expect, db.getRank(1));
 
 		Set<String> rank2Expect = new HashSet<>();
 		Collections.addAll(rank2Expect, "2", "9", "10");
-		Set<String> rank2Actual = new HashSet<>();
-		db.getRank(2).forEach(e -> rank2Actual.add(e.getId()));
-		assertEquals(rank2Expect, rank2Actual);
+		assertUnorderedIDEquals(rank2Expect, db.getRank(2));
 	}
 
 	/**
@@ -162,9 +157,7 @@ public class Neo4jGraphTest {
 			.toRank(2);
 		Set<String> expect = new HashSet<>();
 		Collections.addAll(expect, "7", "5", "3", "11", "8");
-		Set<String> actual = new HashSet<>();
-		db.queryNodes(qd).forEach(e -> actual.add(e.getId()));
-		assertEquals(expect, actual);
+		assertUnorderedIDEquals(expect, db.queryNodes(qd));
 	}
 
 	/**
@@ -176,27 +169,18 @@ public class Neo4jGraphTest {
 			.hasId("2");
 		Set<String> expect = new HashSet<>();
 		Collections.addAll(expect, "2");
-		Set<String> actual = db.queryNodes(qd).stream()
-				.map(sn -> sn.getId())
-				.collect(Collectors.toSet());
-		assertEquals(expect, actual);
+		assertUnorderedIDEquals(expect, db.queryNodes(qd));
 
 		// Also test for multiple ids (reusing the old one)
 		qd = qd.hasId("3");
 		Collections.addAll(expect, "3");
-		actual = db.queryNodes(qd).stream()
-				.map(sn -> sn.getId())
-				.collect(Collectors.toSet());
-		assertEquals(expect, actual);
+		assertUnorderedIDEquals(expect, db.queryNodes(qd));
 
 		// Search for non-existent id.
 		qd = new GraphQueryDescription()
 			.hasId("42");
 		expect = new HashSet<>(); // Empty result.
-		actual = db.queryNodes(qd).stream()
-				.map(sn -> sn.getId())
-				.collect(Collectors.toSet());
-		assertEquals(expect, actual);
+		assertUnorderedIDEquals(expect, db.queryNodes(qd));
 	}
 
 	/**
@@ -210,10 +194,7 @@ public class Neo4jGraphTest {
 		// CHECKSTYLE.ON: MagicNumber
 		Set<String> expect = new HashSet<>();
 		Collections.addAll(expect, "9", "10", "11");
-		Set<String> actual = db.queryNodes(qd).stream()
-				.map(sn -> sn.getId())
-				.collect(Collectors.toSet());
-		assertEquals(expect, actual);
+		assertUnorderedIDEquals(expect, db.queryNodes(qd));
 	}
 
 	/**
@@ -225,30 +206,26 @@ public class Neo4jGraphTest {
 			.containsSource("ASDF");
 		Set<String> expect = new HashSet<>();
 		Collections.addAll(expect, "2", "5", "3", "7", "8");
-		Set<String> actual = db.queryNodes(qd).stream()
-				.map(sn -> sn.getId())
-				.collect(Collectors.toSet());
-		assertEquals(expect, actual);
+		assertUnorderedIDEquals(expect, db.queryNodes(qd));
 
 		// Also test for multiple sources (reusing the old one)
 		qd = qd.containsSource("ASD");
 		Collections.addAll(expect, "9", "10", "11");
-		actual = db.queryNodes(qd).stream()
-				.map(sn -> sn.getId())
-				.collect(Collectors.toSet());
-		assertEquals(expect, actual);
+		assertUnorderedIDEquals(expect, db.queryNodes(qd));
 
 		// Search non-existing source.
 		qd = new GraphQueryDescription()
 			.containsSource("FDSA");
 		// Expect an empty result
 		expect = new HashSet<>();
-		actual = db.queryNodes(qd).stream()
-				.map(sn -> sn.getId())
-				.collect(Collectors.toSet());
-		assertEquals(expect, actual);
+		assertUnorderedIDEquals(expect, db.queryNodes(qd));
 	}
 
+	private static void assertUnorderedIDEquals(Collection<String> expected,
+			Collection<SequenceNode> actual) {
+		assertEquals(expected.stream().collect(Collectors.toSet()),
+				actual.stream().map(sn -> sn.getId()).collect(Collectors.toSet()));
+	}
 	/**
 	 * Clean up after ourselves.
 	 * @throws IOException when the database could not be deleted

--- a/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
+++ b/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
@@ -183,8 +183,16 @@ public class Neo4jGraphTest {
 
 		// Also test for multiple ids (reusing the old one)
 		qd = qd.hasId("3");
-		expect = new HashSet<>();
-		Collections.addAll(expect, "2", "3");
+		Collections.addAll(expect, "3");
+		actual = db.queryNodes(qd).stream()
+				.map(sn -> sn.getId())
+				.collect(Collectors.toSet());
+		assertEquals(expect, actual);
+
+		// Search for non-existent id.
+		qd = new GraphQueryDescription()
+			.hasId("42");
+		expect = new HashSet<>(); // Empty result.
 		actual = db.queryNodes(qd).stream()
 				.map(sn -> sn.getId())
 				.collect(Collectors.toSet());
@@ -216,8 +224,16 @@ public class Neo4jGraphTest {
 		GraphQueryDescription qd = new GraphQueryDescription()
 			.containsSource("ASDF");
 		Set<String> expect = new HashSet<>();
-		Collections.addAll(expect, "2", "9", "10", "5", "3", "7", "11", "8");
+		Collections.addAll(expect, "2", "5", "3", "7", "8");
 		Set<String> actual = db.queryNodes(qd).stream()
+				.map(sn -> sn.getId())
+				.collect(Collectors.toSet());
+		assertEquals(expect, actual);
+
+		// Also test for multiple sources (reusing the old one)
+		qd = qd.containsSource("ASD");
+		Collections.addAll(expect, "9", "10", "11");
+		actual = db.queryNodes(qd).stream()
 				.map(sn -> sn.getId())
 				.collect(Collectors.toSet());
 		assertEquals(expect, actual);

--- a/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
+++ b/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
@@ -20,7 +20,7 @@ import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.core.impl.Edge;
 import nl.tudelft.dnainator.core.impl.SequenceNodeFactoryImpl;
 import nl.tudelft.dnainator.core.impl.SequenceNodeImpl;
-import nl.tudelft.dnainator.graph.GraphQueryDescription;
+import nl.tudelft.dnainator.graph.query.GraphQueryDescription;
 import nl.tudelft.dnainator.parser.EdgeParser;
 import nl.tudelft.dnainator.parser.NodeParser;
 import nl.tudelft.dnainator.parser.exceptions.InvalidEdgeFormatException;

--- a/src/test/resources/strains/topo.node.graph
+++ b/src/test/resources/strains/topo.node.graph
@@ -1,8 +1,8 @@
 > 2 | ASDF | 1 | 5
 TATA
-> 9 | ASDF | 2 | 6
+> 9 | ASD | 2 | 6
 TATA
-> 10 | ASDF | 3 | 7
+> 10 | ASD | 3 | 7
 TATA
 > 5 | ASDF | 4 | 8
 TATA
@@ -10,7 +10,7 @@ TATA
 TATA
 > 7 | ASDF | 6 | 10
 TATA
-> 11 | ASDF | 7 | 11
+> 11 | ASD | 7 | 11
 TATA
 > 8 | ASDF | 8 | 12
 TATA


### PR DESCRIPTION
It now uses the visitor pattern for "compiling" the queries. It's now more easily extendable, although it does require you to change the GraphQuery interface to add a new QueryElement (or "condition" if you will).

Tests were only extended, not altered.

Fixes #58.