### PR TITLE
[RDY] Fix SplashScreen showing no feedback when an exception occurs

### DIFF
--- a/src/main/java/nl/tudelft/dnainator/ui/DNAinator.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/DNAinator.java
@@ -14,6 +14,7 @@ import javafx.stage.Screen;
 import javafx.stage.Stage;
 import nl.tudelft.dnainator.graph.Graph;
 import nl.tudelft.dnainator.graph.impl.Neo4jSingleton;
+import nl.tudelft.dnainator.ui.widgets.dialogs.ExceptionDialog;
 
 import java.io.IOException;
 
@@ -44,6 +45,13 @@ public class DNAinator extends Application {
 			}
 		};
 
+		task.setOnFailed(event -> {
+			Exception e = new RuntimeException(
+						"Could not launch the application. Please make sure only\n"
+								+ "one instance of the application exists at all times.");
+			notifyPreloader(new Preloader.ErrorNotification("DNAinator",
+					"Could not launch the application!", e));
+		});
 		new Thread(task).start();
 	}
 
@@ -69,7 +77,7 @@ public class DNAinator extends Application {
 					primaryStage.setScene(scene);
 					primaryStage.show();
 				} catch (IOException e) {
-					e.printStackTrace();
+					new ExceptionDialog(null, e, "Could not launch the Application!");
 				}
 			});
 		});

--- a/src/main/java/nl/tudelft/dnainator/ui/splashscreen/SplashScreen.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/splashscreen/SplashScreen.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import javafx.application.Platform;
 import nl.tudelft.dnainator.ui.widgets.dialogs.ExceptionDialog;
 import javafx.application.Preloader;
 import javafx.scene.Scene;
@@ -40,8 +41,19 @@ public class SplashScreen extends Preloader {
 	}
 
 	@Override
+	public boolean handleErrorNotification(ErrorNotification info) {
+		new ExceptionDialog(null, info.getCause(),
+				"Could not launch the application!");
+		Platform.exit();
+		return false;
+	}
+
+	@Override
 	public void handleApplicationNotification(PreloaderNotification info) {
 		stage.hide();
+		if (info instanceof ErrorNotification) {
+			handleErrorNotification((ErrorNotification) info);
+		}
 	}
 
 	private Scene createPreloaderScene() {


### PR DESCRIPTION
Fixes #82 
![screen shot 2015-05-23 at 21 22 21](https://cloud.githubusercontent.com/assets/5946464/7785483/427ce310-0192-11e5-9c09-51a9d4533b3e.png)
