### PR TITLE
[RDY] Fix performance of cluster query.

### DIFF
--- a/src/main/java/nl/tudelft/dnainator/graph/impl/query/AllClustersQuery.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/impl/query/AllClustersQuery.java
@@ -50,12 +50,12 @@ public class AllClustersQuery implements Query<Map<Integer, List<Cluster>>> {
 		rootClusters.addAll(clusterFrom.execute(service));
 
 		// Find adjacent clusters as long as there are root clusters in the queue
+		int minrank = rootClusters.stream().mapToInt(e -> e.getStartRank()).min().getAsInt();
 		while (!rootClusters.isEmpty()) {
 			Cluster c = rootClusters.poll();
-			if (c.getStartRank() > maxRank) {
-				break;
+			if (c.getStartRank() < minrank || c.getStartRank() > maxRank) {
+				continue;
 			}
-			// TODO: Might want to introduce a QueryResult class instead of this map
 			result.putIfAbsent(c.getStartRank(), new ArrayList<>());
 			result.get(c.getStartRank()).add(c);
 

--- a/src/main/java/nl/tudelft/dnainator/graph/impl/query/AllClustersQuery.java
+++ b/src/main/java/nl/tudelft/dnainator/graph/impl/query/AllClustersQuery.java
@@ -50,7 +50,7 @@ public class AllClustersQuery implements Query<Map<Integer, List<Cluster>>> {
 		rootClusters.addAll(clusterFrom.execute(service));
 
 		// Find adjacent clusters as long as there are root clusters in the queue
-		int minrank = rootClusters.stream().mapToInt(e -> e.getStartRank()).min().getAsInt();
+		int minrank = rootClusters.stream().mapToInt(e -> e.getStartRank()).min().orElse(0);
 		while (!rootClusters.isEmpty()) {
 			Cluster c = rootClusters.poll();
 			if (c.getStartRank() < minrank || c.getStartRank() > maxRank) {


### PR DESCRIPTION
Two fixes have been provided,
Please comment on whether to use:
- 225541c
Only clusters to the right, with the downside that the start rank is never clustered.
Therefore edges do some weird stuff at the start.  
Upside: is faster.
- acd7787
Clusters to left and right, but does not return or pursue clusters that start before the clusters of the start ranks.  
Upside: possibly more correct.  
Downside: possibly still clusters a huge part of the graph.  
_Correction: since the startRank of the initial clusters is equal to the rank of their startnodes, this downside does not apply._