### PR TITLE
[RDY] Implement one-way coloring of nodes

### DIFF
--- a/src/main/java/nl/tudelft/dnainator/ui/ColorServer.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/ColorServer.java
@@ -11,14 +11,16 @@ import java.util.Map;
  * It keeps a {@link HashMap} of strain sources to CSS classes and uses a {@link BitSet} as a list
  * of occupied colors.
  */
-public final class ColorServer {
+public class ColorServer {
 	private static final String COLOR = "color-";
 	private static final int COLORS = 21;
-	private static ColorServer instance = new ColorServer();
 	private	Map<String, String> colors;
 	private BitSet occupied;
 
-	private ColorServer() {
+	/**
+	 * Instantiates a new {@link ColorServer}.
+	 */
+	public ColorServer() {
 		colors = new HashMap<>(COLORS);
 		occupied = new BitSet(COLORS);
 	}
@@ -56,10 +58,4 @@ public final class ColorServer {
 		occupied.set(index, false);
 	}
 
-	/**
-	 * @return The {@link ColorServer} instance.
-	 */
-	public static ColorServer getInstance() {
-		return instance;
-	}
 }

--- a/src/main/java/nl/tudelft/dnainator/ui/ColorServer.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/ColorServer.java
@@ -1,47 +1,64 @@
 package nl.tudelft.dnainator.ui;
 
+import javafx.collections.FXCollections;
+import javafx.collections.MapChangeListener;
+import javafx.collections.ObservableMap;
+
 import java.util.BitSet;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * The {@link ColorServer} is responsible for managing colors used in the phylogenetic tree and the
  * DNA strains.
- *
- * It keeps a {@link HashMap} of strain sources to CSS classes and uses a {@link BitSet} as a list
- * of occupied colors.
  */
 public class ColorServer {
-	private static final String COLOR = "color-";
 	private static final int COLORS = 21;
-	private	Map<String, String> colors;
+	private String[] colors;
+	private ObservableMap<String, String> map;
 	private BitSet occupied;
 
 	/**
 	 * Instantiates a new {@link ColorServer}.
 	 */
 	public ColorServer() {
-		colors = new HashMap<>(COLORS);
+		colors = new String[COLORS];
+		map = FXCollections.observableHashMap();
 		occupied = new BitSet(COLORS);
+		setColors();
+	}
+
+	private void setColors() {
+		for (int i = 0; i < COLORS; i++) {
+			colors[i] = "color-" + i;
+		}
+	}
+
+	/**
+	 * Returns the style class associated to <code>source</code>, or <code>null</code>.
+	 * @param source The source whose color to find.
+	 * @return The style class associated to the source strain.
+	 */
+	public String getColor(String source) {
+		if (map.containsKey(source)) {
+			return map.get(source);
+		} else {
+			return null;
+		}
 	}
 
 	/**
 	 * @param source The source of the strain to highlight.
-	 * @return The CSS class for an unused color.
 	 * @throws AllColorsInUseException If all colors are currently in use.
 	 */
-	public String getColor(String source) throws AllColorsInUseException {
-		if (colors.containsKey(source)) {
-			return colors.get(source);
+	public void askColor(String source) throws AllColorsInUseException {
+		if (getColor(source) != null) {
+			return;
 		} else if (occupied.cardinality() == COLORS) {
 			throw new AllColorsInUseException();
 		}
 
 		int index = occupied.nextClearBit(0);
 		occupied.set(index, true);
-		String res = COLOR + index;
-		colors.put(source, res);
-		return res;
+		map.put(source, colors[index]);
 	}
 
 	/**
@@ -49,13 +66,20 @@ public class ColorServer {
 	 * @param source The source whose color is now unused.
 	 */
 	public void revokeColor(String source) {
-		if (!colors.containsKey(source)) {
+		if (!map.containsKey(source)) {
 			return;
 		}
 
-		String color = colors.remove(source);
+		String color = map.remove(source);
 		int index = Character.getNumericValue(color.charAt(color.length() - 1));
 		occupied.set(index, false);
 	}
 
+	/**
+	 * Adds a {@link MapChangeListener} to the {@link ObservableMap}.
+	 * @param listener The {@link MapChangeListener} to add.
+	 */
+	public void addListener(MapChangeListener<String, String> listener) {
+		map.addListener(listener);
+	}
 }

--- a/src/main/java/nl/tudelft/dnainator/ui/controllers/WelcomeController.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/controllers/WelcomeController.java
@@ -1,0 +1,37 @@
+package nl.tudelft.dnainator.ui.controllers;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListView;
+
+/**
+ * Controller for the welcome screen.
+ */
+public class WelcomeController {
+	private BooleanProperty done = new SimpleBooleanProperty(false, "done");
+	@SuppressWarnings("unused") @FXML
+	private ListView list;
+	@SuppressWarnings("unused") @FXML
+	private void startButtonAction(ActionEvent e) {
+		done.setValue(true);
+	}
+
+	@SuppressWarnings("unused") @FXML
+	private void initialize() {
+		ObservableList<String> items = FXCollections.observableArrayList(
+				"nl/tudelft/DNAinator/db/10_strains",
+				"nl/tudelft/DNAinator/db/38_strains",
+				"nl/tudelft/DNAinator/db/100_strains");
+		list.setItems(items);
+	}
+	/**
+	 * @return The BooleanProperty used to indicate if the welcome screen is done.
+	 */
+	public BooleanProperty doneProperty() {
+		return done;
+	}
+}

--- a/src/main/java/nl/tudelft/dnainator/ui/controllers/WindowController.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/controllers/WindowController.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.geometry.Orientation;
 import javafx.scene.control.SplitPane;
 import javafx.scene.layout.BorderPane;
+import nl.tudelft.dnainator.ui.ColorServer;
 import nl.tudelft.dnainator.ui.views.PhylogeneticView;
 import nl.tudelft.dnainator.ui.views.StrainView;
 import nl.tudelft.dnainator.ui.widgets.dialogs.AboutDialog;
@@ -35,8 +36,9 @@ public class WindowController {
 	}
 
 	private void createViews() {
-		strainView = new StrainView();
-		PhylogeneticView phyloView = new PhylogeneticView();
+		ColorServer colorServer = new ColorServer();
+		strainView = new StrainView(colorServer);
+		PhylogeneticView phyloView = new PhylogeneticView(colorServer);
 		phyloView.rootProperty().bind(fileOpenerController.treeProperty());
 		SplitPane splitPane = new SplitPane(strainView, phyloView);
 		splitPane.setOrientation(Orientation.VERTICAL);

--- a/src/main/java/nl/tudelft/dnainator/ui/controllers/WindowController.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/controllers/WindowController.java
@@ -3,6 +3,8 @@ package nl.tudelft.dnainator.ui.controllers;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.geometry.Orientation;
+import javafx.scene.control.SplitPane;
 import javafx.scene.layout.BorderPane;
 import nl.tudelft.dnainator.ui.views.PhylogeneticView;
 import nl.tudelft.dnainator.ui.views.StrainView;
@@ -19,19 +21,26 @@ public class WindowController {
 	@SuppressWarnings("unused") @FXML
 	private BorderPane root;
 	@SuppressWarnings("unused") @FXML
-	private StrainView strainView;
-	@SuppressWarnings("unused") @FXML
-	private PhylogeneticView phyloView;
-	@SuppressWarnings("unused") @FXML
 	private FileOpenController fileOpenerController;
+	@SuppressWarnings("unused") @FXML
+	private WelcomeController welcomeController;
+	private StrainView strainView;
 
-	/**
-	 * Constructs a WindowController object, binding <code>rootProperty</code> of the
-	 * {@link PhylogeneticView} the <code>treeProperty</code> of the {@link FileOpenController}.
-	 */
 	@SuppressWarnings("unused") @FXML
 	private void initialize() {
+		welcomeController.doneProperty().addListener((obj, oldV, newV) -> {
+			createViews();
+			welcomeController.doneProperty().unbind();
+		});
+	}
+
+	private void createViews() {
+		strainView = new StrainView();
+		PhylogeneticView phyloView = new PhylogeneticView();
 		phyloView.rootProperty().bind(fileOpenerController.treeProperty());
+		SplitPane splitPane = new SplitPane(strainView, phyloView);
+		splitPane.setOrientation(Orientation.VERTICAL);
+		root.setCenter(splitPane);
 	}
 
 	@SuppressWarnings("unused") @FXML

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/ClusterDrawable.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/ClusterDrawable.java
@@ -1,13 +1,19 @@
 package nl.tudelft.dnainator.ui.drawables;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import javafx.collections.MapChangeListener;
 import javafx.scene.Group;
+import javafx.scene.Node;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Shape;
 import javafx.scene.text.Text;
 import nl.tudelft.dnainator.core.SequenceNode;
+import nl.tudelft.dnainator.ui.ColorServer;
 
 /**
  * The {@link ClusterDrawable} class represents the mid level object in the viewable model.
@@ -15,22 +21,70 @@ import nl.tudelft.dnainator.core.SequenceNode;
 public class ClusterDrawable extends Group {
 	private static final int CLUSTER_SIZE = 3;
 	private List<SequenceNode> clustered;
+	private Set<String> sources;
 	private Shape shape;
+	private Text label;
 
 	/**
 	 * Construct a new mid level {@link ClusterDrawable} using the default graph.
+	 * @param colorServer the {@link ColorServer} to bind to.
 	 * @param clustered	the clustered {@link SequenceNode}s in this cluster.
 	 */
-	public ClusterDrawable(List<SequenceNode> clustered) {
+	public ClusterDrawable(ColorServer colorServer, List<SequenceNode> clustered) {
 		this.clustered = clustered;
-
-		shape = new Circle(CLUSTER_SIZE, Color.BLUE);
+		this.sources = new HashSet<>();
+		for (SequenceNode n : clustered) {
+			for (String src : n.getSource().split(",")) {
+				sources.add(src);
+			}
+		}
+		//this.sources = clustered.stream()
+		//		.flatMap(node -> node.getSource().split(","))
+		//		.collect(Collectors.toSet());
+		shape = new Circle(CLUSTER_SIZE);
 		shape.setOnMouseClicked(e -> System.out.println(clustered));
-		Text label = new Text(Integer.toString(clustered.size()));
+		label = new Text(Integer.toString(clustered.size()));
 		label.setStyle("-fx-font-size: 2pt");
+
+		checkForColor(colorServer);
+		colorServer.addListener(change -> onColorServerChanged(change));
 
 		getChildren().add(shape);
 		getChildren().add(label);
+	}
+
+	private void checkForColor(ColorServer colorServer) {
+		for (String source : sources) {
+			String style = colorServer.getColor(source);
+			if (style != null) {
+				addStyle(style);
+			}
+		}
+	}
+
+	private void onColorServerChanged(
+			MapChangeListener.Change<? extends String, ? extends String> change) {
+		sources.stream().forEach(source -> {
+			if (source.equals(change.getKey())) {
+				if (change.wasAdded()) {
+					addStyle(change.getValueAdded());
+				} else {
+					removeStyle(change.getValueRemoved());
+				}
+			}
+		});
+	}
+
+	private void addStyle(String style) {
+		for (Node node : getChildren()) {
+			node.getStyleClass().add(style);
+		}
+	}
+
+	private void removeStyle(String style) {
+		for (Node node : getChildren()) {
+			node.getStyleClass().remove(style);
+		}
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/Drawable.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/Drawable.java
@@ -1,0 +1,20 @@
+package nl.tudelft.dnainator.ui.drawables;
+
+/**
+ * An interface that each drawable should implement.
+ */
+public interface Drawable {
+	/**
+	 * Applies the CSS class <code>style</code> to all
+	 * children of this drawable.
+	 * @param style The CSS class to apply.
+	 */
+	void addStyle(String style);
+
+	/**
+	 * Removes the CSS class <code>style</code> from
+	 * all children of this drawable.
+	 * @param style The CSS class to remove.
+	 */
+	void removeStyle(String style);
+}

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/AbstractNode.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/AbstractNode.java
@@ -5,15 +5,17 @@ import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.Group;
+import javafx.scene.Node;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.Shape;
+import nl.tudelft.dnainator.ui.drawables.Drawable;
 
 /**
  * An abstract node for use in a phylogenetic tree. It provides the basic implementation
  * for a node in the phylogenetic tree, and forms an abstract interface for both leaf and
  * internal nodes.
  */
-public abstract class AbstractNode extends Group {
+public abstract class AbstractNode extends Group implements Drawable {
 	protected static final int DIM = 8;
 	protected DoubleProperty margin = new SimpleDoubleProperty(0, "margin");
 	protected IntegerProperty leafCount = new SimpleIntegerProperty(0, "leafCount");
@@ -29,7 +31,8 @@ public abstract class AbstractNode extends Group {
 	}
 
 	/**
-	 * @return the shape of this node. Default is a centered rectangle.
+	 * Allows each implementing class to define its own {@link Shape}.
+	 * @return The {@link Shape} to use in the implementing class. Default is a centered rectangle.
 	 */
 	public Shape getShape() {
 		return new Rectangle(0 - DIM / 2, 0 - DIM / 2, DIM, DIM);
@@ -41,20 +44,18 @@ public abstract class AbstractNode extends Group {
 	 */
 	public abstract void onMouseClicked();
 
-	/**
-	 * Adds a CSS class to the {@link AbstractNode}.
-	 * @param style The CSS class to add.
-	 */
-	protected void addStyle(String style) {
-		shape.getStyleClass().add(style);
+	@Override
+	public void addStyle(String style) {
+		for (Node child : getChildren()) {
+			child.getStyleClass().add(style);
+		}
 	}
 
-	/**
-	 * Removes all CSS classes from the {@link AbstractNode}.
-	 * @param style The CSS class to remove.
-	 */
-	protected void removeStyle(String style) {
-		shape.getStyleClass().remove(style);
+	@Override
+	public void removeStyle(String style) {
+		for (Node child : getChildren()) {
+			child.getStyleClass().remove(style);
+		}
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/AbstractNode.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/AbstractNode.java
@@ -51,9 +51,10 @@ public abstract class AbstractNode extends Group {
 
 	/**
 	 * Removes all CSS classes from the {@link AbstractNode}.
+	 * @param style The CSS class to remove.
 	 */
-	protected void removeStyles() {
-		shape.getStyleClass().clear();
+	protected void removeStyle(String style) {
+		shape.getStyleClass().remove(style);
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/LeafNode.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/LeafNode.java
@@ -1,8 +1,12 @@
 package nl.tudelft.dnainator.ui.drawables.phylogeny;
 
+import javafx.collections.MapChangeListener;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import nl.tudelft.dnainator.tree.TreeNode;
+import nl.tudelft.dnainator.ui.AllColorsInUseException;
+import nl.tudelft.dnainator.ui.ColorServer;
+import nl.tudelft.dnainator.ui.widgets.dialogs.ExceptionDialog;
 
 /**
  * This class represents leaf nodes in the phylogenetic tree. Each leaf node has a reference to
@@ -14,16 +18,24 @@ public class LeafNode extends AbstractNode {
 	protected static final int LABEL_Y_OFFSET = 4;
 	private TreeNode node;
 	private Text label;
+	private ColorServer colorServer;
 	private boolean highlighted;
 
 	/**
 	 * Constructs a new {@link LeafNode}.
 	 * @param node The original treenode.
+	 * @param colorServer The {@link ColorServer} to bind to for colors.
 	 */
-	public LeafNode(TreeNode node) {
+	public LeafNode(TreeNode node, ColorServer colorServer) {
 		this.node = node;
 		this.label = new Text(LABEL_X_OFFSET, LABEL_Y_OFFSET, node.getName());
 		this.label.onMouseClickedProperty().bind(shape.onMouseClickedProperty());
+		this.colorServer = colorServer;
+		this.colorServer.addListener(change -> {
+			if (change.getKey().equals(node.getName())) {
+				onColorServerChanged(change);
+			}
+		});
 		this.highlighted = false;
 		this.marginProperty().set(LEAFHEIGHT);
 		this.leafCountProperty().set(1);
@@ -32,20 +44,27 @@ public class LeafNode extends AbstractNode {
 		getChildren().add(label);
 	}
 
+	private void onColorServerChanged(
+			MapChangeListener.Change<? extends String, ? extends String> change) {
+		if (change.wasAdded()) {
+			highlighted = true;
+			addStyle(change.getValueAdded());
+		} else {
+			highlighted = false;
+			removeStyle(change.getValueRemoved());
+		}
+	}
+
 	@Override
 	public void onMouseClicked() {
-		removeStyles();
 		if (!highlighted) {
-			//try {
-				//String color = ColorServer.getInstance().getColor(node.getName());
-				//addStyle(color);
-				highlighted = true;
-			//} catch (AllColorsInUseException e) {
-			//	new ExceptionDialog(null, e, "The maximum amount of colors are in use");
-			//}
+			try {
+				colorServer.askColor(node.getName());
+			} catch (AllColorsInUseException e) {
+				new ExceptionDialog(null, e, "All colors are currently in use!");
+			}
 		} else {
-			//ColorServer.getInstance().revokeColor(node.getName());
-			highlighted = false;
+			colorServer.revokeColor(node.getName());
 		}
 	}
 
@@ -56,8 +75,8 @@ public class LeafNode extends AbstractNode {
 	}
 
 	@Override
-	protected void removeStyles() {
-		shape.getStyleClass().clear();
-		label.getStyleClass().clear();
+	protected void removeStyle(String style) {
+		shape.getStyleClass().remove(style);
+		label.getStyleClass().remove(style);
 	}
 }

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/LeafNode.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/LeafNode.java
@@ -3,9 +3,6 @@ package nl.tudelft.dnainator.ui.drawables.phylogeny;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import nl.tudelft.dnainator.tree.TreeNode;
-import nl.tudelft.dnainator.ui.AllColorsInUseException;
-import nl.tudelft.dnainator.ui.ColorServer;
-import nl.tudelft.dnainator.ui.widgets.dialogs.ExceptionDialog;
 
 /**
  * This class represents leaf nodes in the phylogenetic tree. Each leaf node has a reference to
@@ -39,15 +36,15 @@ public class LeafNode extends AbstractNode {
 	public void onMouseClicked() {
 		removeStyles();
 		if (!highlighted) {
-			try {
-				String color = ColorServer.getInstance().getColor(node.getName());
-				addStyle(color);
+			//try {
+				//String color = ColorServer.getInstance().getColor(node.getName());
+				//addStyle(color);
 				highlighted = true;
-			} catch (AllColorsInUseException e) {
-				new ExceptionDialog(null, e, "The maximum amount of colors are in use");
-			}
+			//} catch (AllColorsInUseException e) {
+			//	new ExceptionDialog(null, e, "The maximum amount of colors are in use");
+			//}
 		} else {
-			ColorServer.getInstance().revokeColor(node.getName());
+			//ColorServer.getInstance().revokeColor(node.getName());
 			highlighted = false;
 		}
 	}

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/LeafNode.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/phylogeny/LeafNode.java
@@ -67,16 +67,4 @@ public class LeafNode extends AbstractNode {
 			colorServer.revokeColor(node.getName());
 		}
 	}
-
-	@Override
-	protected void addStyle(String style) {
-		shape.getStyleClass().add(style);
-		label.getStyleClass().add(style);
-	}
-
-	@Override
-	protected void removeStyle(String style) {
-		shape.getStyleClass().remove(style);
-		label.getStyleClass().remove(style);
-	}
 }

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/strains/ClusterDrawable.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/strains/ClusterDrawable.java
@@ -17,7 +17,13 @@ import nl.tudelft.dnainator.ui.drawables.Drawable;
  * The {@link ClusterDrawable} class represents the mid level object in the viewable model.
  */
 public class ClusterDrawable extends Group implements Drawable {
-	private static final int CLUSTER_SIZE = 3;
+	private static final int SINGLE = 1;
+	private static final int SMALL = 3;
+	private static final int MEDIUM = 10;
+	private static final double SINGLE_RADIUS = 2;
+	private static final double SMALL_RADIUS = 4;
+	private static final double MEDIUM_RADIUS = 5;
+	private static final double LARGE_RADIUS = 6;
 	private static final int PIETHRESHOLD = 10;
 	private List<SequenceNode> clustered;
 	private Set<String> sources;
@@ -38,8 +44,14 @@ public class ClusterDrawable extends Group implements Drawable {
 		label = new Text(Integer.toString(clustered.size()));
 		label.setStyle("-fx-font-size: 2pt");
 
+		draw(colorServer);
+	}
+
+	private void draw(ColorServer colorServer) {
+		double radius = getRadius();
+
 		if (sources.size() > PIETHRESHOLD) {
-			getChildren().add(new Circle(CLUSTER_SIZE));
+			getChildren().add(new Circle(radius));
 		} else {
 			colorServer.addListener(this::onColorServerChanged);
 
@@ -47,10 +59,24 @@ public class ClusterDrawable extends Group implements Drawable {
 					.map(e -> colorServer.getColor(e))
 					.filter(e -> e != null)
 					.collect(Collectors.toList());
-			pie = new Pie(CLUSTER_SIZE, collect);
+			pie = new Pie(radius, collect);
 			getChildren().add(pie);
 		}
 		getChildren().add(label);
+	}
+
+	private double getRadius() {
+		int nChildren = clustered.size();
+
+		if (nChildren == SINGLE) {
+			return SINGLE_RADIUS;
+		} else if (nChildren <= SMALL) {
+			return SMALL_RADIUS;
+		} else if (nChildren <= MEDIUM) {
+			return MEDIUM_RADIUS;
+		} else {
+			return LARGE_RADIUS;
+		}
 	}
 
 	private void onColorServerChanged(

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/strains/ClusterDrawable.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/strains/ClusterDrawable.java
@@ -1,24 +1,23 @@
-package nl.tudelft.dnainator.ui.drawables;
+package nl.tudelft.dnainator.ui.drawables.strains;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javafx.collections.MapChangeListener;
 import javafx.scene.Group;
 import javafx.scene.Node;
-import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Shape;
 import javafx.scene.text.Text;
 import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.ui.ColorServer;
+import nl.tudelft.dnainator.ui.drawables.Drawable;
 
 /**
  * The {@link ClusterDrawable} class represents the mid level object in the viewable model.
  */
-public class ClusterDrawable extends Group {
+public class ClusterDrawable extends Group implements Drawable {
 	private static final int CLUSTER_SIZE = 3;
 	private List<SequenceNode> clustered;
 	private Set<String> sources;
@@ -75,13 +74,15 @@ public class ClusterDrawable extends Group {
 		});
 	}
 
-	private void addStyle(String style) {
+	@Override
+	public void addStyle(String style) {
 		for (Node node : getChildren()) {
 			node.getStyleClass().add(style);
 		}
 	}
 
-	private void removeStyle(String style) {
+	@Override
+	public void removeStyle(String style) {
 		for (Node node : getChildren()) {
 			node.getStyleClass().remove(style);
 		}

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/strains/Edge.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/strains/Edge.java
@@ -1,4 +1,4 @@
-package nl.tudelft.dnainator.ui.drawables;
+package nl.tudelft.dnainator.ui.drawables.strains;
 
 import javafx.scene.shape.Line;
 import nl.tudelft.dnainator.ui.widgets.contexts.EdgeContext;
@@ -6,16 +6,16 @@ import nl.tudelft.dnainator.ui.widgets.contexts.EdgeContext;
 /**
  * The drawable edge is a line that can be bound to the a source and a destination cluster.
  */
-public class DrawableEdge extends Line {
+public class Edge extends Line {
 	/**
-	 * Instantiate a new DrawableEdge.
+	 * Instantiate a new Edge.
 	 * @param src This edge's source node.
 	 * @param dest This edge's destination node.
 	 */
-	public DrawableEdge(ClusterDrawable src, ClusterDrawable dest) {
+	public Edge(ClusterDrawable src, ClusterDrawable dest) {
 		getStyleClass().add("drawable-edge");
 		setOnContextMenuRequested(e -> {
-			EdgeContext.getInstance().show(DrawableEdge.this, e.getScreenX(), e.getScreenY());
+			EdgeContext.getInstance().show(Edge.this, e.getScreenX(), e.getScreenY());
 			e.consume();
 		});
 		

--- a/src/main/java/nl/tudelft/dnainator/ui/drawables/strains/Pie.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/drawables/strains/Pie.java
@@ -1,0 +1,66 @@
+package nl.tudelft.dnainator.ui.drawables.strains;
+
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableSet;
+import javafx.collections.SetChangeListener;
+import javafx.scene.Group;
+import javafx.scene.shape.Arc;
+import javafx.scene.shape.ArcType;
+import javafx.scene.shape.Circle;
+
+/**
+ * This class represents a JavaFX drawable that will display a list of styles as a piechart.
+ * Styles can be added and removed, which will trigger redrawing of the chart.
+ */
+public class Pie extends Group {
+	private static final int FULLCIRCLE = 360;
+	private ObservableSet<String> styles;
+	private Group slices;
+	private double radius;
+
+	/**
+	 * Construct a new Pie using the specified radius and styles.
+	 * @param radius	the radius
+	 * @param styles	the list of styles (data)
+	 */
+	public Pie(double radius, List<String> styles) {
+		this.radius = radius;
+		this.slices = new Group();
+		this.styles = FXCollections.observableSet();
+		this.styles.addListener(this::onChange);
+
+		getChildren().addAll(new Circle(radius), slices);
+		styles.forEach(e -> this.styles.add(e));
+	}
+
+	/**
+	 * Return the list of styles.
+	 * @return	the styles
+	 */
+	public ObservableSet<String> getStyles() {
+		return styles;
+	}
+
+	// The parameter is needed to distinguish what type of listener has to be added,
+	// so suppress it for PMD et al.
+	@SuppressWarnings("unused")
+	private void onChange(SetChangeListener.Change<? extends String> change) {
+		if (styles.isEmpty()) {
+			return;
+		}
+
+		slices.getChildren().clear();
+		int start = 0;
+		int delta = FULLCIRCLE / styles.size();
+		for (String style : styles) {
+			Arc arc = new Arc(0, 0, radius, radius, start, delta);
+			arc.setType(ArcType.ROUND);
+			arc.getStyleClass().add(style);
+			slices.getChildren().add(arc);
+
+			start += delta;
+		}
+	}
+}

--- a/src/main/java/nl/tudelft/dnainator/ui/models/GraphItem.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/models/GraphItem.java
@@ -14,8 +14,8 @@ import nl.tudelft.dnainator.core.impl.Cluster;
 import nl.tudelft.dnainator.graph.Graph;
 import nl.tudelft.dnainator.graph.impl.Neo4jSingleton;
 import nl.tudelft.dnainator.ui.ColorServer;
-import nl.tudelft.dnainator.ui.drawables.ClusterDrawable;
-import nl.tudelft.dnainator.ui.drawables.DrawableEdge;
+import nl.tudelft.dnainator.ui.drawables.strains.ClusterDrawable;
+import nl.tudelft.dnainator.ui.drawables.strains.Edge;
 
 /**
  * The {@link GraphItem} class represents the graph that contains the DNA strain.
@@ -121,7 +121,7 @@ public class GraphItem extends Group {
 				cluster.getClustered().stream().flatMap(e -> e.getOutgoing().stream())
 						.filter(clusters::containsKey)
 						.filter(i -> clusters.get(i) != cluster)
-						.map(o -> new DrawableEdge(cluster, clusters.get(o)))
+						.map(o -> new Edge(cluster, clusters.get(o)))
 						.collect(Collectors.toList()));
 	}
 

--- a/src/main/java/nl/tudelft/dnainator/ui/models/GraphItem.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/models/GraphItem.java
@@ -13,6 +13,7 @@ import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.core.impl.Cluster;
 import nl.tudelft.dnainator.graph.Graph;
 import nl.tudelft.dnainator.graph.impl.Neo4jSingleton;
+import nl.tudelft.dnainator.ui.ColorServer;
 import nl.tudelft.dnainator.ui.drawables.ClusterDrawable;
 import nl.tudelft.dnainator.ui.drawables.DrawableEdge;
 
@@ -28,6 +29,7 @@ public class GraphItem extends Group {
 	private static final int SLICES = 4;
 	private static final int CLUSTER_DIVIDER = 100;
 
+	private ColorServer colorServer;
 	private Graph graph;
 	private Map<String, ClusterDrawable> clusters;
 	private Group content;
@@ -35,27 +37,31 @@ public class GraphItem extends Group {
 
 	/**
 	 * Construct a new top level {@link GraphItem} using the default graph.
+	 * @param colorServer The {@link ColorServer} to bind to.
 	 */
-	public GraphItem() {
-		this(Neo4jSingleton.getInstance().getDatabase(), new Group(), new Group());
+	public GraphItem(ColorServer colorServer) {
+		this(colorServer, Neo4jSingleton.getInstance().getDatabase(), new Group(), new Group());
 	}
 
 	/**
 	 * Construct a new top level {@link GraphItem} using the specified graph.
+	 * @param colorServer The {@link ColorServer} to bind to.
 	 * @param graph	The specified graph.
 	 */
-	public GraphItem(Graph graph) {
-		this(graph, new Group(), new Group());
+	public GraphItem(ColorServer colorServer, Graph graph) {
+		this(colorServer, graph, new Group(), new Group());
 	}
 
 	/**
 	 * Construct a new top level {@link GraphItem} using the specified graph, content and child
 	 * content.
+	 * @param colorServer The {@link ColorServer} to bind to.
 	 * @param graph	The specified graph.
 	 * @param content The specified graph content.
 	 * @param childContent The specified child content.
 	 */
-	public GraphItem(Graph graph, Group content, Group childContent) {
+	public GraphItem(ColorServer colorServer, Graph graph, Group content, Group childContent) {
+		this.colorServer = colorServer;
 		this.graph = graph;
 		this.clusters = new HashMap<>();
 		this.content = content;
@@ -121,7 +127,7 @@ public class GraphItem extends Group {
 
 	private void loadRank(Integer key, List<Cluster> value) {
 		for (int i = 0; i < value.size(); i++) {
-			ClusterDrawable cluster = new ClusterDrawable(value.get(i).getNodes());
+			ClusterDrawable cluster = new ClusterDrawable(colorServer, value.get(i).getNodes());
 			cluster.getClustered().forEach(e -> clusters.put(e.getId(), cluster));
 			cluster.setTranslateX(key * RANK_WIDTH);
 			cluster.setTranslateY(i * RANK_WIDTH - value.size() * RANK_WIDTH / 2);

--- a/src/main/java/nl/tudelft/dnainator/ui/views/PhylogeneticView.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/views/PhylogeneticView.java
@@ -44,7 +44,7 @@ public class PhylogeneticView extends AbstractView {
 
 	private AbstractNode draw(TreeNode node) {
 		if (node.getChildren().size() == 0) {
-			return new LeafNode(node);
+			return new LeafNode(node, colorServer);
 		}
 
 		AbstractNode self = new InternalNode(node.getChildren().stream()

--- a/src/main/java/nl/tudelft/dnainator/ui/views/PhylogeneticView.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/views/PhylogeneticView.java
@@ -7,6 +7,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.transform.Affine;
 import javafx.scene.transform.Scale;
 import nl.tudelft.dnainator.tree.TreeNode;
+import nl.tudelft.dnainator.ui.ColorServer;
 import nl.tudelft.dnainator.ui.drawables.phylogeny.AbstractNode;
 import nl.tudelft.dnainator.ui.drawables.phylogeny.InternalNode;
 import nl.tudelft.dnainator.ui.drawables.phylogeny.LeafNode;
@@ -17,12 +18,15 @@ import nl.tudelft.dnainator.ui.drawables.phylogeny.LeafNode;
 public class PhylogeneticView extends AbstractView {
 	private static final int SCALE = 1;
 	private ObjectProperty<TreeNode> rootProperty = new SimpleObjectProperty<>(null, "root");
+	private ColorServer colorServer;
 
 	/**
 	 * Constructs a new {@link PhylogeneticView}.
+	 * @param colorServer The {@link ColorServer} to communicate with.
 	 */
-	public PhylogeneticView() {
+	public PhylogeneticView(ColorServer colorServer) {
 		super();
+		this.colorServer = colorServer;
 		rootProperty().addListener((obj, oldV, newV) -> redraw());
 	}
 

--- a/src/main/java/nl/tudelft/dnainator/ui/views/StrainView.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/views/StrainView.java
@@ -1,6 +1,7 @@
 package nl.tudelft.dnainator.ui.views;
 
 import javafx.geometry.Point2D;
+import nl.tudelft.dnainator.ui.ColorServer;
 import nl.tudelft.dnainator.ui.models.GraphItem;
 import nl.tudelft.dnainator.ui.widgets.contexts.ViewContext;
 
@@ -12,8 +13,9 @@ public class StrainView extends AbstractView {
 
 	/**
 	 * Creates a new strain view instance.
+	 * @param colorServer The {@link ColorServer} to communicate with.
 	 */
-	public StrainView() {
+	public StrainView(ColorServer colorServer) {
 		super();
 
 		setOnContextMenuRequested(e -> {

--- a/src/main/java/nl/tudelft/dnainator/ui/views/StrainView.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/views/StrainView.java
@@ -23,7 +23,7 @@ public class StrainView extends AbstractView {
 			e.consume();
 		});
 
-		gi = new GraphItem();
+		gi = new GraphItem(colorServer);
 		setTransforms(gi);
 		getChildren().add(gi);
 	}

--- a/src/main/java/nl/tudelft/dnainator/ui/widgets/contexts/EdgeContext.java
+++ b/src/main/java/nl/tudelft/dnainator/ui/widgets/contexts/EdgeContext.java
@@ -2,10 +2,10 @@ package nl.tudelft.dnainator.ui.widgets.contexts;
 
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
-import nl.tudelft.dnainator.ui.drawables.DrawableEdge;
+import nl.tudelft.dnainator.ui.drawables.strains.Edge;
 
 /**
- * Creates a {@link ContextMenu} for {@link DrawableEdge}s. It needs to be singleton because
+ * Creates a {@link ContextMenu} for {@link Edge}s. It needs to be singleton because
  * only one context menu may exist per context, thus only one instance of this class may
  * exist at a time.
  */

--- a/src/main/resources/ui/fxml/dnainator.fxml
+++ b/src/main/resources/ui/fxml/dnainator.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.input.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import nl.tudelft.dnainator.ui.views.*?>
 
 <BorderPane fx:id="root" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" stylesheets="@../style.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="nl.tudelft.dnainator.ui.controllers.WindowController">
    <top>
@@ -88,12 +87,7 @@
       </MenuBar>
    </top>
    <center>
-      <SplitPane fx:id="splitPane" orientation="VERTICAL">
-         <items>
-            <StrainView fx:id="strainView" />
-            <PhylogeneticView fx:id="phyloView" />
-         </items>
-      </SplitPane>
+      <fx:include fx:id="welcome" source="welcome.fxml"/>
    </center>
    <left>
       <fx:include fx:id="fileOpener" source="openpane.fxml"/>

--- a/src/main/resources/ui/fxml/welcome.fxml
+++ b/src/main/resources/ui/fxml/welcome.fxml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.*?>
+<?import java.lang.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.text.Font?>
+<?import javafx.scene.control.Button?>
+
+
+<AnchorPane xmlns="http://javafx.com/javafx/8.0.45" xmlns:fx="http://javafx.com/fxml/1" fx:controller="nl.tudelft.dnainator.ui.controllers.WelcomeController">
+   <children>
+      <ListView fx:id="list" prefHeight="200.0" prefWidth="400.0" AnchorPane.bottomAnchor="100.0" AnchorPane.leftAnchor="100.0" AnchorPane.rightAnchor="100.0" AnchorPane.topAnchor="100.0" />
+        <Button onAction="#startButtonAction" text="Start" AnchorPane.bottomAnchor="20.0" AnchorPane.rightAnchor="20.0" />
+        <Label alignment="CENTER" text="Welcome" textAlignment="CENTER" AnchorPane.leftAnchor="100.0" AnchorPane.rightAnchor="100.0" AnchorPane.topAnchor="20.0">
+            <font>
+                <Font size="32.0" />
+            </font>
+        </Label>
+      <Label alignment="CENTER" text="Please choose a database to open, or press Control+O to open a new file" textAlignment="CENTER" AnchorPane.leftAnchor="100.0" AnchorPane.rightAnchor="100.0" AnchorPane.topAnchor="80.0" />
+   </children>
+</AnchorPane>

--- a/src/test/java/nl/tudelft/dnainator/ui/ColorServerTest.java
+++ b/src/test/java/nl/tudelft/dnainator/ui/ColorServerTest.java
@@ -1,5 +1,6 @@
 package nl.tudelft.dnainator.ui;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -12,6 +13,15 @@ import static org.junit.Assert.assertTrue;
 public class ColorServerTest {
 	private static final String TKK_REF = "TKK_REF";
 	private static final String TKK_REF_0026 = "TKK_REF_0026";
+	private ColorServer colorServer;
+
+	/**
+	 * Sets up the test environment.
+	 */
+	@Before
+	public void setup() {
+		colorServer = new ColorServer();
+	}
 
 	/**
 	 * Tests whether simply getting one color that is not used yet, works.
@@ -19,9 +29,9 @@ public class ColorServerTest {
 	 */
 	@Test
 	public void testGetColorSimple() throws AllColorsInUseException {
-		String col0 = ColorServer.getInstance().getColor(TKK_REF);
+		String col0 = colorServer.getColor(TKK_REF);
 		assertEquals("color-0", col0);
-		ColorServer.getInstance().revokeColor(TKK_REF);
+		colorServer.revokeColor(TKK_REF);
 	}
 
 	/**
@@ -30,12 +40,12 @@ public class ColorServerTest {
 	 */
 	@Test
 	public void testGetColorMultiple() throws AllColorsInUseException {
-		String col0 = ColorServer.getInstance().getColor(TKK_REF);
+		String col0 = colorServer.getColor(TKK_REF);
 		assertEquals("color-0", col0);
-		String col1 = ColorServer.getInstance().getColor(TKK_REF_0026);
+		String col1 = colorServer.getColor(TKK_REF_0026);
 		assertEquals("color-1", col1);
-		ColorServer.getInstance().revokeColor(TKK_REF);
-		ColorServer.getInstance().revokeColor(TKK_REF_0026);
+		colorServer.revokeColor(TKK_REF);
+		colorServer.revokeColor(TKK_REF_0026);
 	}
 
 	/**
@@ -44,10 +54,10 @@ public class ColorServerTest {
 	 */
 	@Test
 	public void testGetColorSame() throws AllColorsInUseException {
-		String col0 = ColorServer.getInstance().getColor(TKK_REF);
-		String col1 = ColorServer.getInstance().getColor(TKK_REF);
+		String col0 = colorServer.getColor(TKK_REF);
+		String col1 = colorServer.getColor(TKK_REF);
 		assertTrue(col0 == col1);
-		ColorServer.getInstance().revokeColor(TKK_REF);
+		colorServer.revokeColor(TKK_REF);
 	}
 
 	/**
@@ -56,12 +66,12 @@ public class ColorServerTest {
 	 */
 	@Test
 	public void testRevoke() throws AllColorsInUseException {
-		String col0 = ColorServer.getInstance().getColor(TKK_REF);
+		String col0 = colorServer.getColor(TKK_REF);
 		assertEquals("color-0", col0);
-		ColorServer.getInstance().revokeColor(TKK_REF);
-		String col1 = ColorServer.getInstance().getColor(TKK_REF);
+		colorServer.revokeColor(TKK_REF);
+		String col1 = colorServer.getColor(TKK_REF);
 		assertEquals("color-0", col1);
 		assertFalse(col0 == col1);
-		ColorServer.getInstance().revokeColor(TKK_REF);
+		colorServer.revokeColor(TKK_REF);
 	}
 }

--- a/src/test/java/nl/tudelft/dnainator/ui/ColorServerTest.java
+++ b/src/test/java/nl/tudelft/dnainator/ui/ColorServerTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -29,6 +28,7 @@ public class ColorServerTest {
 	 */
 	@Test
 	public void testGetColorSimple() throws AllColorsInUseException {
+		colorServer.askColor(TKK_REF);
 		String col0 = colorServer.getColor(TKK_REF);
 		assertEquals("color-0", col0);
 		colorServer.revokeColor(TKK_REF);
@@ -40,8 +40,10 @@ public class ColorServerTest {
 	 */
 	@Test
 	public void testGetColorMultiple() throws AllColorsInUseException {
+		colorServer.askColor(TKK_REF);
 		String col0 = colorServer.getColor(TKK_REF);
 		assertEquals("color-0", col0);
+		colorServer.askColor(TKK_REF_0026);
 		String col1 = colorServer.getColor(TKK_REF_0026);
 		assertEquals("color-1", col1);
 		colorServer.revokeColor(TKK_REF);
@@ -54,6 +56,7 @@ public class ColorServerTest {
 	 */
 	@Test
 	public void testGetColorSame() throws AllColorsInUseException {
+		colorServer.askColor(TKK_REF);
 		String col0 = colorServer.getColor(TKK_REF);
 		String col1 = colorServer.getColor(TKK_REF);
 		assertTrue(col0 == col1);
@@ -66,12 +69,14 @@ public class ColorServerTest {
 	 */
 	@Test
 	public void testRevoke() throws AllColorsInUseException {
+		colorServer.askColor(TKK_REF);
 		String col0 = colorServer.getColor(TKK_REF);
 		assertEquals("color-0", col0);
 		colorServer.revokeColor(TKK_REF);
+		colorServer.askColor(TKK_REF);
 		String col1 = colorServer.getColor(TKK_REF);
 		assertEquals("color-0", col1);
-		assertFalse(col0 == col1);
+		assertTrue(col0 == col1);
 		colorServer.revokeColor(TKK_REF);
 	}
 }

--- a/src/test/java/nl/tudelft/dnainator/ui/models/GraphItemTest.java
+++ b/src/test/java/nl/tudelft/dnainator/ui/models/GraphItemTest.java
@@ -12,6 +12,7 @@ import javafx.scene.Node;
 import javafx.scene.shape.Rectangle;
 import nl.tudelft.dnainator.graph.Graph;
 
+import nl.tudelft.dnainator.ui.ColorServer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +38,7 @@ public class GraphItemTest {
 	public void setup() {
 		child = new Group();
 		content = new Group();
-		gi = new GraphItem(graph, content, child);
+		gi = new GraphItem(new ColorServer(), graph, content, child);
 	}
 
 	/**


### PR DESCRIPTION
This PR enables color-sync from the `PhylogeneticView` to the `StrainView`: if colors are applied on phylogenetic leaf nodes, they are also automatically applied to the clusters.

Performance is a bit sloppy at the moment, due to the sheer amount of redraws. Also, applying colors the other way around is not yet implemented because we want customer feedback for this.

**TODO**
* ~~Set cluster size depending on the amount of sequence nodes it contains;~~
* The welcome screen is really bad...