### PR TITLE
[RDY] Consume arrow key event, reorder annotation field in FXML

### DIFF
--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/controllers/AbstractViewController.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/controllers/AbstractViewController.java
@@ -57,6 +57,7 @@ public class AbstractViewController {
 		KeyCode key = e.getCode();
 
 		if (key.isArrowKey()) {
+			e.consume();
 			scrollTo(key);
 		} else if (key == KeyCode.PLUS || key == KeyCode.EQUALS) {
 			view.zoomIn();

--- a/dnainator-javafx/src/main/resources/fxml/openpane.fxml
+++ b/dnainator-javafx/src/main/resources/fxml/openpane.fxml
@@ -8,7 +8,8 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
-<GridPane fx:id="fileOpenPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="0" minWidth="0" prefHeight="300.0" prefWidth="550" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="nl.tudelft.dnainator.javafx.controllers.FileOpenController">
+
+<GridPane fx:id="fileOpenPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="0" minWidth="0" prefHeight="300.0" prefWidth="550" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" fx:controller="nl.tudelft.dnainator.javafx.controllers.FileOpenController">
   <columnConstraints>
     <ColumnConstraints fillWidth="false" hgrow="SOMETIMES" minWidth="0.0" prefWidth="50.0" />
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="300.0" />
@@ -42,15 +43,15 @@
       <Label fx:id="curNodeLabel" styleClass="gray-label" stylesheets="@../style.css" text="Current node file: " GridPane.columnIndex="1" GridPane.rowIndex="1" />
       <Label fx:id="curEdgeLabel" styleClass="gray-label" stylesheets="@../style.css" text="Current edge file: " GridPane.columnIndex="1" GridPane.rowIndex="3" />
       <Label fx:id="curNewickLabel" styleClass="gray-label" stylesheets="@../style.css" text="Current newick file: " GridPane.columnIndex="1" GridPane.rowIndex="5" />
+      <Label text="Annotations file:" GridPane.rowIndex="6" />
+      <TextField fx:id="gffField" onMouseClicked="#onGFFFieldClicked" promptText="*.gff" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+      <Label fx:id="curGffLabel" styleClass="gray-label" stylesheets="@../style.css" text="Current annotations file: " GridPane.columnIndex="1" GridPane.rowIndex="7" />
       <HBox alignment="CENTER_RIGHT" prefHeight="100.0" prefWidth="200.0" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="8">
          <children>
             <Button fx:id="openButton" disable="true" mnemonicParsing="false" onAction="#onOpenAction" text="Open" />
             <Button fx:id="cancelButton" mnemonicParsing="false" onAction="#onCancelAction" text="Cancel" />
          </children>
       </HBox>
-      <Label text="Annotations file:" GridPane.rowIndex="6" />
-      <TextField fx:id="gffField" onMouseClicked="#onGFFFieldClicked" promptText="*.gff" GridPane.columnIndex="1" GridPane.rowIndex="6" />
-      <Label fx:id="curGffLabel" styleClass="gray-label" stylesheets="@../style.css" text="Current annotations file: " GridPane.columnIndex="1" GridPane.rowIndex="7" />
    </children>
    <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />


### PR DESCRIPTION
Fixes #120.
Additionally, put the annotation input field in the FXML above the Hbox with buttons.
This is so the ordering using navigation (tab/shift-tab) maintains a logical order from top to bottom (with left having focus before right).