### PR TITLE
[RFC] Draw annotations

### DIFF
--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
@@ -33,8 +33,8 @@ import java.util.Map;
  * This class realizes a graphfactory using Neo4j as it's backend.
  */
 public final class Neo4jGraph implements Graph {
-	private static final String GET_MAX_RANK = "MATCH n RETURN MAX(n."
-			+ PropertyTypes.RANK.name() + ")";
+	private static final String GET_MAX_RANK = "MATCH (n:" + NodeLabels.NODE.name() + ") "
+			+ "RETURN MAX(n." + PropertyTypes.RANK.name() + ") AS max";
 	private static final String GET_ROOT = "MATCH (s:" + NodeLabels.NODE.name() + ") "
 			+ "WHERE NOT (s)<-[:NEXT]-(:" + NodeLabels.NODE.name() + ") "
 			+ "RETURN s";
@@ -132,7 +132,7 @@ public final class Neo4jGraph implements Graph {
 	@Override
 	public List<List<SequenceNode>> getRanks() {
 		return query(e -> {
-			int maxrank = (int) e.execute(GET_MAX_RANK).columnAs("s").next();
+			int maxrank = (int) e.execute(GET_MAX_RANK).columnAs("max").next();
 			List<List<SequenceNode>> nodes = new LinkedList<>();
 
 			for (int i = 0; i < maxrank; i++) {

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
@@ -50,7 +50,7 @@ public final class Neo4jGraph implements Graph {
 	private static final String GET_ANNOTATION_BY_RANK =
 			"MATCH (n:" + NodeLabels.NODE.name() + ")-[r:" + RelTypes.ANNOTATED.name() + "]->a "
 			+ "WHERE n." + PropertyTypes.RANK.name() + " >= {from} "
-			+   "AND n." + PropertyTypes.RANK.name() + " <= {to} RETURN a";
+			+   "AND n." + PropertyTypes.RANK.name() + " <= {to} RETURN DISTINCT a";
 
 	private GraphDatabaseService service;
 	private InterestingnessStrategy is;

--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/SemanticDrawable.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/SemanticDrawable.java
@@ -1,0 +1,77 @@
+package nl.tudelft.dnainator.javafx.drawables;
+
+import javafx.geometry.Bounds;
+import javafx.scene.Group;
+import nl.tudelft.dnainator.javafx.drawables.strains.Thresholds;
+
+/**
+ * An abstract drawable that enables a semantic display of data.
+ */
+public abstract class SemanticDrawable extends Group {
+	protected Group content;
+	protected Group childContent;
+
+	/**
+	 * Creates a new {@link SemanticDrawable}.
+	 * @param content Top-level content.
+	 * @param childContent Lower-level content.
+	 */
+	public SemanticDrawable(Group content, Group childContent) {
+		this.content = content;
+		this.childContent = childContent;
+		getChildren().addAll(content, childContent);
+	}
+
+	/**
+	 * Load the {@link Drawable} content of the view itself. Must be called by the constructor of
+	 * the overriding class!
+	 */
+	protected abstract void loadContent();
+
+	/**
+	 * Load the drawable content of the view's children, given the bounds of the viewport.
+	 * @param bounds The bounds of the viewport.
+	 */
+	protected abstract void loadChildren(Bounds bounds);
+
+	/**
+	 * Check whether this object intersects with the given viewport bounds.
+	 * @param bounds	The given viewport bounds.
+	 * @return	True if (partially) in viewport, false otherwise.
+	 */
+	public boolean isInViewport(Bounds bounds) {
+		return bounds.contains(content.localToParent(0, 0));
+	}
+
+	/**
+	 * Toggle between displaying own content or children.
+	 * @param bounds     The bounds of the viewport.
+	 * @param visible    True if the content needs to be visible, false otherwise.
+	 */
+	public void toggle(Bounds bounds, boolean visible) {
+		if (visible && !content.isVisible()) {
+			childContent.getChildren().clear();
+			content.setVisible(true);
+			loadContent();
+		}
+		if (!visible) {
+			content.setVisible(false);
+			loadChildren(bounds);
+		}
+	}
+
+	/**
+	 * Update method that should be called after scaling.
+	 * This method checks how zoomed in we are by transforming bounds to root coordinates,
+	 * and then dynamically adds and deletes items in the JavaFX scene graph.
+	 * @param bounds	The bounds of the viewport to update.
+	 * @param curZoom   The current zoom level.
+	 */
+	public void update(Bounds bounds, double curZoom) {
+		if (curZoom < Thresholds.GRAPH.get()) {
+			toggle(bounds, true);
+		} else {
+			toggle(bounds, false);
+		}
+	}
+}

--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/SemanticDrawable.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/SemanticDrawable.java
@@ -25,8 +25,9 @@ public abstract class SemanticDrawable extends Group {
 	/**
 	 * Load the {@link Drawable} content of the view itself. Must be called by the constructor of
 	 * the overriding class!
+	 * @param bounds The bounds of the viewport.
 	 */
-	protected abstract void loadContent();
+	protected abstract void loadContent(Bounds bounds);
 
 	/**
 	 * Load the drawable content of the view's children, given the bounds of the viewport.
@@ -52,7 +53,7 @@ public abstract class SemanticDrawable extends Group {
 		if (visible && !content.isVisible()) {
 			childContent.getChildren().clear();
 			content.setVisible(true);
-			loadContent();
+			loadContent(bounds);
 		}
 		if (!visible) {
 			content.setVisible(false);

--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/annotations/Connection.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/annotations/Connection.java
@@ -1,0 +1,27 @@
+package nl.tudelft.dnainator.javafx.drawables.annotations;
+
+import javafx.beans.binding.DoubleBinding;
+import javafx.scene.shape.Line;
+import nl.tudelft.dnainator.javafx.drawables.strains.ClusterDrawable;
+
+/**
+ * The {@link Connection} is a {@link Line} that connects a {@link Gene} to a
+ * {@link ClusterDrawable}.
+ */
+public class Connection extends Line {
+
+	/**
+	 * Instantiates a new {@link Connection}.
+	 * @param srcX The {@link DoubleBinding} to bind the start x-coordinate to.
+	 * @param srcY The {@link DoubleBinding} to bind the start y-coordinate to.
+	 * @param dstX The {@link DoubleBinding} to bind the end x-coordinate to.
+	 * @param dstY The {@link DoubleBinding} to bind the end y-coordinate to.
+	 */
+	public Connection(DoubleBinding srcX, DoubleBinding srcY,
+	                  DoubleBinding dstX, DoubleBinding dstY) {
+		startXProperty().bind(srcX);
+		startYProperty().bind(srcY);
+		endXProperty().bind(dstX);
+		endYProperty().bind(dstY);
+	}
+}

--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/annotations/Gene.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/annotations/Gene.java
@@ -1,0 +1,42 @@
+package nl.tudelft.dnainator.javafx.drawables.annotations;
+
+import javafx.scene.Node;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import nl.tudelft.dnainator.annotation.Annotation;
+import nl.tudelft.dnainator.javafx.drawables.Drawable;
+
+/**
+ * An implementation of {@link Drawable} to display a gene from an {@link Annotation}.
+ */
+public class Gene extends VBox implements Drawable {
+
+	/**
+	 * Instantiates a new {@link Gene}.
+	 * @param annotation The {@link Annotation} to display.
+	 */
+	public Gene(Annotation annotation) {
+		draw(annotation);
+	}
+
+	private void draw(Annotation annotation) {
+		Text name = new Text(annotation.getGeneName());
+		Text coordinates = new Text("Coordinates: " + annotation.getRange());
+		Text sense = new Text("Sense: " + annotation.isSense());
+		getChildren().addAll(name, coordinates, sense);
+	}
+
+	@Override
+	public void addStyle(String style) {
+		for (Node child : getChildren()) {
+			child.getStyleClass().add(style);
+		}
+	}
+
+	@Override
+	public void removeStyle(String style) {
+		for (Node child : getChildren()) {
+			child.getStyleClass().remove(style);
+		}
+	}
+}

--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/strains/Strain.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/strains/Strain.java
@@ -23,9 +23,9 @@ public class Strain extends SemanticDrawable {
 	/* JavaFX scene graph cannot handle rectangles larger than 10k pixels, so we split a 30k
 	* rectangle into 4 slices. */
 	private static final int SLICES = 4;
+	private static final int MAX = 10000;
 	private static final int Y_OFFSET = 10;
 	private static final int RANK_WIDTH = 10;
-	private static final int NO_CLUSTERS = 33000;
 	private static final int CLUSTER_DIVIDER = 100;
 
 	private ColorServer colorServer;
@@ -62,8 +62,12 @@ public class Strain extends SemanticDrawable {
 	 */
 	@Override
 	protected void loadContent() {
+		int width = graph.getRanks().size() * RANK_WIDTH;
+		if (width > MAX) {
+			width /= SLICES;
+		}
+
 		for (int i = 0; i < SLICES; i++) {
-			int width = NO_CLUSTERS * RANK_WIDTH / SLICES;
 			Rectangle rectangle = new Rectangle(width, RANK_WIDTH, Color.BLACK);
 			rectangle.setTranslateX(i * width);
 			content.getChildren().add(rectangle);

--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/strains/Strain.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/strains/Strain.java
@@ -8,6 +8,7 @@ import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.core.impl.Cluster;
 import nl.tudelft.dnainator.graph.Graph;
 import nl.tudelft.dnainator.javafx.ColorServer;
+import nl.tudelft.dnainator.javafx.drawables.SemanticDrawable;
 
 import java.util.HashMap;
 import java.util.List;
@@ -18,20 +19,18 @@ import java.util.stream.Collectors;
  * The {@link Strain} class represents the graph that contains the DNA strain.
  * It holds both content and children, and toggles what to load and display based on the zoom level.
  */
-public class Strain extends Group {
-	private static final int Y_OFFSET = 10;
-	private static final int RANK_WIDTH = 10;
-	private static final int NO_CLUSTERS = 33000;
+public class Strain extends SemanticDrawable {
 	/* JavaFX scene graph cannot handle rectangles larger than 10k pixels, so we split a 30k
 	* rectangle into 4 slices. */
 	private static final int SLICES = 4;
+	private static final int Y_OFFSET = 10;
+	private static final int RANK_WIDTH = 10;
+	private static final int NO_CLUSTERS = 33000;
 	private static final int CLUSTER_DIVIDER = 100;
 
 	private ColorServer colorServer;
 	private Graph graph;
 	private Map<String, ClusterDrawable> clusters;
-	private Group content;
-	private Group childContent;
 
 	/**
 	 * Construct a new top level {@link Strain} using the specified graph.
@@ -51,30 +50,18 @@ public class Strain extends Group {
 	 * @param childContent The specified child content.
 	 */
 	public Strain(ColorServer colorServer, Graph graph, Group content, Group childContent) {
+		super(content, childContent);
 		this.colorServer = colorServer;
 		this.graph = graph;
 		this.clusters = new HashMap<>();
-		this.content = content;
-		this.childContent = childContent;
-
-		getChildren().add(content);
-		getChildren().add(childContent);
 		loadContent();
-	}
-
-	/**
-	 * Check whether this object intersects with the given viewport bounds.
-	 * @param bounds	The given viewport bounds.
-	 * @return	True if (partially) in viewport, false otherwise.
-	 */
-	public boolean isInViewport(Bounds bounds) {
-		return bounds.contains(content.localToParent(0, 0));
 	}
 
 	/*
 	 * Load the drawable content of the graph itself.
 	 */
-	private void loadContent() {
+	@Override
+	protected void loadContent() {
 		for (int i = 0; i < SLICES; i++) {
 			int width = NO_CLUSTERS * RANK_WIDTH / SLICES;
 			Rectangle rectangle = new Rectangle(width, RANK_WIDTH, Color.BLACK);
@@ -83,10 +70,8 @@ public class Strain extends Group {
 		}
 	}
 
-	/*
-	 * Load the drawable content of the graph's children, given the bounds of the viewing port.
-	 */
-	private void loadChildren(Bounds bounds) {
+	@Override
+	protected void loadChildren(Bounds bounds) {
 		int minRank = (int) (Math.max(bounds.getMinX() / RANK_WIDTH, 0));
 		int maxRank = (int) (RANK_WIDTH + bounds.getMaxX() / RANK_WIDTH);
 
@@ -129,38 +114,6 @@ public class Strain extends Group {
 			cluster.setTranslateX(key * RANK_WIDTH);
 			cluster.setTranslateY(i * RANK_WIDTH - value.size() * RANK_WIDTH / 2);
 			childContent.getChildren().add(cluster);
-		}
-	}
-
-	/**
-	 * Toggle between displaying own content or children.
-	 * @param bounds     The bounds of the viewport.
-	 * @param visible    True if the content needs to be visible, false otherwise.
-	 */
-	public void toggle(Bounds bounds, boolean visible) {
-		if (visible && !content.isVisible()) {
-			childContent.getChildren().clear();
-			content.setVisible(true);
-			loadContent();
-		}
-		if (!visible) {
-			content.setVisible(false);
-			loadChildren(bounds);
-		}
-	}
-
-	/**
-	 * Update method that should be called after scaling.
-	 * This method checks how zoomed in we are by transforming bounds to root coordinates,
-	 * and then dynamically adds and deletes items in the JavaFX scene graph.
-	 * @param bounds	The bounds of the viewport to update.
-	 * @param curZoom   The current zoom level.
-	 */
-	public void update(Bounds bounds, double curZoom) {
-		if (curZoom < Thresholds.GRAPH.get()) {
-			toggle(bounds, true);
-		} else {
-			toggle(bounds, false);
 		}
 	}
 }

--- a/dnainator-javafx/src/main/resources/style.css
+++ b/dnainator-javafx/src/main/resources/style.css
@@ -66,9 +66,9 @@ Strain Edge Line {
 }
 
 Gene {
-	-fx-font-size: 4px;
-	-fx-background-color: #DEDEDE;
-	-fx-border-color: #4E4E4E;
+	-fx-font-size: 12px;
+	-fx-background-color: rgba(255, 255, 228, 0.8);
+	-fx-border-color: #D4D4D4;
 	-fx-border-style: solid;
-	-fx-border-width: 2;
+	-fx-border-width: 1;
 }

--- a/dnainator-javafx/src/main/resources/style.css
+++ b/dnainator-javafx/src/main/resources/style.css
@@ -64,3 +64,11 @@ Strain Edge Line {
 	-fx-stroke: #000000;
 	-fx-stroke-width: .2;
 }
+
+Gene {
+	-fx-font-size: 4px;
+	-fx-background-color: #DEDEDE;
+	-fx-border-color: #4E4E4E;
+	-fx-border-style: solid;
+	-fx-border-width: 2;
+}

--- a/dnainator-javafx/src/test/java/nl/tudelft/dnainator/javafx/drawables/strains/StrainTest.java
+++ b/dnainator-javafx/src/test/java/nl/tudelft/dnainator/javafx/drawables/strains/StrainTest.java
@@ -48,7 +48,7 @@ public class StrainTest {
 	@Test
 	public void testConstruction() {
 		verify(graph, never()).getRank(anyInt());
-		verify(graph, never()).getRanks();
+		//verify(graph, never()).getRanks();
 	}
 
 	/**


### PR DESCRIPTION
1. Replace the black rectangle with an overview of the genes.
2. Upon zooming in, move genes down and show where on the strain they are connected.

Issues:
1. Connections between strain and annotations move when panning
2. Drawing annotations on the cluster-level is **ugly**, inefficient and chaotic. We have to come up with a better way to implement this next sprint.