### PR TITLE
[RDY] Differentiate between the nodes returned by the parser, and those returned by the graph.

### DIFF
--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/core/EnrichedSequenceNode.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/core/EnrichedSequenceNode.java
@@ -1,0 +1,33 @@
+package nl.tudelft.dnainator.core;
+
+import java.util.List;
+
+import nl.tudelft.dnainator.annotation.Annotation;
+import nl.tudelft.dnainator.graph.interestingness.ScoreContainer;
+
+/**
+ * An enriched {@link SequenceNode}, which is enriched with respect to an ordinary
+ * {@link SequenceNode} because it also contains outgoing edges, its rank within
+ * the graph, scores and annotations.
+ */
+public interface EnrichedSequenceNode extends SequenceNode, ScoreContainer {
+
+	/**
+	 * The associated annotations.
+	 * @return	the annotations
+	 */
+	List<Annotation> getAnnotations();
+
+	/**
+	 * The associated incoming neighbours.
+	 * @return	a list of neighbour id's
+	 */
+	List<String> getOutgoing();
+
+	/**
+	 * The associated rank.
+	 * @return	the rank
+	 */
+	int getRank();
+
+}

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/core/SequenceNode.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/core/SequenceNode.java
@@ -1,9 +1,6 @@
 package nl.tudelft.dnainator.core;
 
-import java.util.List;
 import java.util.Set;
-
-import nl.tudelft.dnainator.annotation.Annotation;
 
 /**
  * Interface that all sequences should implement.
@@ -14,12 +11,6 @@ public interface SequenceNode {
 	 * @return	the id of this sequence
 	 */
 	String getId();
-
-	/**
-	 * The associated annotations.
-	 * @return	the annotations
-	 */
-	List<Annotation> getAnnotations();
 
 	/**
 	 * The associated source strains.
@@ -45,22 +36,10 @@ public interface SequenceNode {
 	 */
 	String getSequence();
 
-	/**
-	 * The associated rank.
-	 * @return	the rank
-	 */
-	int getRank();
-
 	@Override
 	boolean equals(Object other);
 
 	@Override
 	int hashCode();
-
-	/**
-	 * The associated incoming neighbours.
-	 * @return	a list of neighbour id's
-	 */
-	List<String> getOutgoing();
 
 }

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/core/impl/Cluster.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/core/impl/Cluster.java
@@ -1,6 +1,7 @@
 package nl.tudelft.dnainator.core.impl;
 
 import nl.tudelft.dnainator.annotation.Annotation;
+import nl.tudelft.dnainator.core.EnrichedSequenceNode;
 import nl.tudelft.dnainator.core.SequenceNode;
 
 import java.util.List;
@@ -9,7 +10,7 @@ import java.util.List;
  * A cluster is a node that contains one or more clustered {@link SequenceNode}s.
  */
 public class Cluster {
-	private List<SequenceNode> nodes;
+	private List<EnrichedSequenceNode> nodes;
 	private int rankStart;
 	private List<Annotation> annotations;
 
@@ -19,12 +20,14 @@ public class Cluster {
 	 * This will be used for positioning this {@link Cluster}.
 	 * @param rankStart	the start rank of this {@link Cluster}
 	 * @param annotations	the annotations associated with this cluster
-	 * @param list		the list of {@link SequenceNode}s
+	 * @param nodes		the list of {@link EnrichedSequenceNode}s in this
+	 * cluster.
 	 */
-	public Cluster(int rankStart, List<SequenceNode> list, List<Annotation> annotations) {
+	public Cluster(int rankStart, List<EnrichedSequenceNode> nodes,
+			List<Annotation> annotations) {
 		this.rankStart = rankStart;
 		this.annotations = annotations;
-		this.nodes = list;
+		this.nodes = nodes;
 	}
 
 	/**
@@ -39,7 +42,7 @@ public class Cluster {
 	 * Return this {@link Cluster}s list of {@link SequenceNode}s.
 	 * @return	the list of {@link SequenceNode}s
 	 */
-	public List<SequenceNode> getNodes() {
+	public List<EnrichedSequenceNode> getNodes() {
 		return nodes;
 	}
 

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/core/impl/SequenceNodeImpl.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/core/impl/SequenceNodeImpl.java
@@ -1,9 +1,7 @@
 package nl.tudelft.dnainator.core.impl;
 
-import nl.tudelft.dnainator.annotation.Annotation;
 import nl.tudelft.dnainator.core.SequenceNode;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -16,10 +14,7 @@ public class SequenceNodeImpl implements SequenceNode {
 	private int start;
 	private int end;
 	private String sequence;
-	private int rank;
-	private List<Annotation> annotations;
 	private Set<String> sources;
-	private List<String> outgoing;
 
 	/**
 	 * Constructs a default sequence with all parameters specified.
@@ -42,39 +37,16 @@ public class SequenceNodeImpl implements SequenceNode {
 	 * @param sequence The sequence.
 	 */
 	public SequenceNodeImpl(String id, Set<String> sources, int start, int end, String sequence) {
-		this(id, sources, start, end, sequence, 0, new ArrayList<>());
-	}
-
-	/**
-	 * Constructs a default sequence with all parameters specified.
-	 * @param id The ID of this sequence.
-	 * @param sources The sources of the sequence (from where it was sequenced).
-	 * @param start The start position of the sequence.
-	 * @param end The end position of the sequence.
-	 * @param sequence The sequence.
-	 * @param rank The rank.
-	 * @param outgoing The neighbours
-	 */
-	public SequenceNodeImpl(String id, Set<String> sources,
-			int start, int end, String sequence, int rank, List<String> outgoing) {
 		this.id = id;
 		this.start = start;
 		this.end = end;
 		this.sequence = sequence;
-		this.rank = rank;
-		this.annotations = new ArrayList<>();
 		this.sources = sources;
-		this.outgoing = outgoing;
 	}
 
 	@Override
 	public String getId() {
 		return id;
-	}
-
-	@Override
-	public List<Annotation> getAnnotations() {
-		return annotations;
 	}
 
 	@Override
@@ -118,15 +90,5 @@ public class SequenceNodeImpl implements SequenceNode {
 	@Override
 	public String toString() {
 		return "SequenceNode<" + getId() + "," + sequence.length() + ">";
-	}
-
-	@Override
-	public int getRank() {
-		return rank;
-	}
-
-	@Override
-	public List<String> getOutgoing() {
-		return outgoing;
 	}
 }

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/Graph.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/Graph.java
@@ -3,7 +3,7 @@ package nl.tudelft.dnainator.graph;
 import nl.tudelft.dnainator.annotation.Annotation;
 import nl.tudelft.dnainator.annotation.AnnotationCollection;
 import nl.tudelft.dnainator.annotation.Range;
-import nl.tudelft.dnainator.core.SequenceNode;
+import nl.tudelft.dnainator.core.EnrichedSequenceNode;
 import nl.tudelft.dnainator.core.impl.Cluster;
 import nl.tudelft.dnainator.graph.interestingness.InterestingnessStrategy;
 import nl.tudelft.dnainator.graph.query.GraphQueryDescription;
@@ -21,14 +21,14 @@ public interface Graph extends AnnotationCollection {
 	 * FIXME: This is the node that has no incoming edges.
 	 * @return	a SequenceNode
 	 */
-	SequenceNode getRootNode();
+	EnrichedSequenceNode getRootNode();
 
 	/**
 	 * Get the node with identifier n from this graph.
 	 * @param n	the identifier
 	 * @return	a SequenceNode
 	 */
-	SequenceNode getNode(String n);
+	EnrichedSequenceNode getNode(String n);
 
 	/**
 	 * @return The {@link AnnotationCollection} containing the annotations.
@@ -40,13 +40,13 @@ public interface Graph extends AnnotationCollection {
 	 * @param rank	the rank
 	 * @return		a list of sequence nodes
 	 */
-	List<SequenceNode> getRank(int rank);
+	List<EnrichedSequenceNode> getRank(int rank);
 
 	/**
 	 * Get a list of all nodes from this graph.
 	 * @return	a list of all nodes, per rank
 	 */
-	List<List<SequenceNode>> getRanks();
+	List<List<EnrichedSequenceNode>> getRanks();
 
 	/**
 	 * Return a list of nodes that belong to the same cluster as the given startId.
@@ -69,7 +69,7 @@ public interface Graph extends AnnotationCollection {
 	 * @param q the query for finding the nodes.
 	 * @return the result of the query.
 	 */
-	List<SequenceNode> queryNodes(GraphQueryDescription q);
+	List<EnrichedSequenceNode> queryNodes(GraphQueryDescription q);
 
 	/**
 	 * Return all annotations covered by the given range of ranks.

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
@@ -4,6 +4,7 @@ import nl.tudelft.dnainator.annotation.Annotation;
 import nl.tudelft.dnainator.annotation.AnnotationCollection;
 import nl.tudelft.dnainator.annotation.AnnotationCollectionFactory;
 import nl.tudelft.dnainator.annotation.Range;
+import nl.tudelft.dnainator.core.EnrichedSequenceNode;
 import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.core.impl.Cluster;
 import nl.tudelft.dnainator.graph.Graph;
@@ -92,12 +93,12 @@ public final class Neo4jGraph implements Graph {
 	}
 
 	@Override
-	public SequenceNode getRootNode() {
+	public EnrichedSequenceNode getRootNode() {
 		return query(e -> createSequenceNode(getRoot()));
 	}
 
 	@Override
-	public SequenceNode getNode(String s) {
+	public EnrichedSequenceNode getNode(String s) {
 		return query(e -> createSequenceNode(e.findNode(NodeLabels.NODE,
 				PropertyTypes.ID.name(), s)));
 	}
@@ -108,11 +109,11 @@ public final class Neo4jGraph implements Graph {
 	}
 
 	@Override
-	public List<SequenceNode> getRank(int rank) {
+	public List<EnrichedSequenceNode> getRank(int rank) {
 		return query(e -> {
 			ResourceIterator<Node> res = e.findNodes(NodeLabels.NODE,
 					PropertyTypes.RANK.name(), rank);
-			List<SequenceNode> nodes = new LinkedList<>();
+			List<EnrichedSequenceNode> nodes = new LinkedList<>();
 			res.forEachRemaining(n -> nodes.add(createSequenceNode(n)));
 
 			return nodes;
@@ -125,15 +126,15 @@ public final class Neo4jGraph implements Graph {
 	 * @param node from the database.
 	 * @return a {@link SequenceNode} with the information of the given {@link Node}.
 	 */
-	public SequenceNode createSequenceNode(Node node) {
+	public EnrichedSequenceNode createSequenceNode(Node node) {
 		return new Neo4jSequenceNode(service, node);
 	}
 
 	@Override
-	public List<List<SequenceNode>> getRanks() {
+	public List<List<EnrichedSequenceNode>> getRanks() {
 		return query(e -> {
 			int maxrank = (int) e.execute(GET_MAX_RANK).columnAs("max").next();
-			List<List<SequenceNode>> nodes = new LinkedList<>();
+			List<List<EnrichedSequenceNode>> nodes = new LinkedList<>();
 
 			for (int i = 0; i < maxrank; i++) {
 				nodes.add(getRank(i));
@@ -150,7 +151,7 @@ public final class Neo4jGraph implements Graph {
 	}
 
 	@Override
-	public List<SequenceNode> queryNodes(GraphQueryDescription qd) {
+	public List<EnrichedSequenceNode> queryNodes(GraphQueryDescription qd) {
 		return Neo4jQuery.of(qd).execute(service);
 	}
 

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jQuery.java
@@ -1,5 +1,6 @@
 package nl.tudelft.dnainator.graph.impl;
 
+import nl.tudelft.dnainator.core.EnrichedSequenceNode;
 import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.graph.query.GraphQuery;
 import nl.tudelft.dnainator.graph.query.GraphQueryDescription;
@@ -8,6 +9,7 @@ import nl.tudelft.dnainator.graph.query.PredicateFilter;
 import nl.tudelft.dnainator.graph.query.RankEnd;
 import nl.tudelft.dnainator.graph.query.RankStart;
 import nl.tudelft.dnainator.graph.query.SourcesFilter;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
@@ -56,9 +58,9 @@ public final class Neo4jQuery implements GraphQuery {
 	 * @param db the database to execute the query on.
 	 * @return the query result.
 	 */
-	public List<SequenceNode> execute(GraphDatabaseService db) {
+	public List<EnrichedSequenceNode> execute(GraphDatabaseService db) {
 		sb.append("RETURN n");
-		List<SequenceNode> result;
+		List<EnrichedSequenceNode> result;
 		try (Transaction tx = db.beginTx()) {
 			Result r = db.execute(sb.toString(), parameters);
 			ResourceIterator<Node> it = r.columnAs("n");

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/query/AllClustersQuery.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/query/AllClustersQuery.java
@@ -1,7 +1,7 @@
 package nl.tudelft.dnainator.graph.impl.query;
 
 import nl.tudelft.dnainator.annotation.Annotation;
-import nl.tudelft.dnainator.core.SequenceNode;
+import nl.tudelft.dnainator.core.EnrichedSequenceNode;
 import nl.tudelft.dnainator.core.impl.Cluster;
 import nl.tudelft.dnainator.graph.impl.Neo4jSequenceNode;
 import nl.tudelft.dnainator.graph.impl.NodeLabels;
@@ -120,12 +120,12 @@ public class AllClustersQuery implements Query<Map<Integer, List<Cluster>>> {
 				rankStart = endRank;
 			}
 		}
-
 		// Might want to internally pass nodes.
-		List<SequenceNode> retrieve = result.stream().map(e -> new Neo4jSequenceNode(service, e))
-						.collect(Collectors.toList());
+		List<EnrichedSequenceNode> retrieve = result.stream()
+				.map(e -> new Neo4jSequenceNode(service, e))
+				.collect(Collectors.toList());
 		List<Annotation> annotations = retrieve.stream().flatMap(e -> e.getAnnotations().stream())
-						.collect(Collectors.toList());
+				.collect(Collectors.toList());
 		cluster = new Cluster(rankStart, retrieve, annotations);
 		return cluster;
 	}

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/interestingness/ScoreContainer.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/interestingness/ScoreContainer.java
@@ -1,5 +1,10 @@
 package nl.tudelft.dnainator.graph.interestingness;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 /**
  * Represents a location within the graph.
  */
@@ -11,4 +16,15 @@ public interface ScoreContainer {
 	 * @return the score of a particular property
 	 */
 	int getScore(ScoreIdentifier id);
+
+	/**
+	 * Returns all of the scores of this {@link ScoreContainer}. This uses getScore
+	 * by default, but may be optimized by overriding it if the scores are stored
+	 * internally as a {@link Map}.
+	 * @return all of the scores of this {@link ScoreContainer}.
+	 */
+	default Map<ScoreIdentifier, Integer> getScores() {
+		return Arrays.stream(Scores.values())
+				.collect(Collectors.toMap(Function.identity(), this::getScore));
+	}
 }

--- a/dnainator-core/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
+++ b/dnainator-core/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
@@ -3,6 +3,7 @@ package nl.tudelft.dnainator.graph.impl;
 import nl.tudelft.dnainator.annotation.Annotation;
 import nl.tudelft.dnainator.annotation.impl.AnnotationCollectionImpl;
 import nl.tudelft.dnainator.annotation.impl.AnnotationImpl;
+import nl.tudelft.dnainator.core.EnrichedSequenceNode;
 import nl.tudelft.dnainator.core.SequenceNode;
 import nl.tudelft.dnainator.core.impl.Edge;
 import nl.tudelft.dnainator.core.impl.SequenceNodeFactoryImpl;
@@ -267,7 +268,7 @@ public class Neo4jGraphTest {
 
 
 	private static void assertUnorderedIDEquals(Collection<String> expected,
-			Collection<SequenceNode> actual) {
+			Collection<EnrichedSequenceNode> actual) {
 		assertEquals(expected.stream().collect(Collectors.toSet()),
 				actual.stream().map(sn -> sn.getId()).collect(Collectors.toSet()));
 	}

--- a/dnainator-javafx/src/test/java/nl/tudelft/dnainator/javafx/drawables/strains/ClusterDrawableTest.java
+++ b/dnainator-javafx/src/test/java/nl/tudelft/dnainator/javafx/drawables/strains/ClusterDrawableTest.java
@@ -1,6 +1,6 @@
 package nl.tudelft.dnainator.javafx.drawables.strains;
 
-import nl.tudelft.dnainator.core.SequenceNode;
+import nl.tudelft.dnainator.core.EnrichedSequenceNode;
 import nl.tudelft.dnainator.core.impl.Cluster;
 import nl.tudelft.dnainator.javafx.ColorServer;
 
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterDrawableTest {
 	@Mock private ColorServer colorserver;
-	@Mock private SequenceNode node;
+	@Mock private EnrichedSequenceNode node;
 	
 	private ClusterDrawable cluster;
 	


### PR DESCRIPTION
Adds a new interface, called `EnrichedSequenceNode`, which is a `SequenceNode` also containing its outgoing edges, its rank, its scores and its annotations.