### PR TITLE
[RDY] Pull ranking out of constructor, into the GraphBuilder. Fully apply Builder pattern.

### DIFF
--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/GraphBuilder.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/GraphBuilder.java
@@ -16,14 +16,16 @@ public interface GraphBuilder {
 	/**
 	 * Add an {@link Edge} to the graph.
 	 * @param edge The edge containing the source and destination node.
+	 * @return the {@link GraphBuilder}, after adding the edge.
 	 */
-	void addEdge(Edge<String> edge);
+	GraphBuilder addEdge(Edge<String> edge);
 
 	/**
 	 * Add a {@link SequenceNode} to the graph.
 	 * @param s The node to be added.
+	 * @return the {@link GraphBuilder}, after adding the node.
 	 */
-	void addNode(SequenceNode s);
+	GraphBuilder addNode(SequenceNode s);
 
 	/**
 	 * Construct a graph using the supplied parsers as a source for nodes and edges.
@@ -31,14 +33,27 @@ public interface GraphBuilder {
 	 * @param ep The {@link EdgeParser} to supply the edges.
 	 * @throws IOException If something goes wrong with IO while parsing.
 	 * @throws ParseException if one of the input files is invalid.
+	 * @return the {@link GraphBuilder}, after adding the nodes and edges.
 	 */
-	default void constructGraph(NodeParser np, EdgeParser ep)
+	default GraphBuilder constructGraph(NodeParser np, EdgeParser ep)
 			throws IOException, ParseException {
-		while (np.hasNext()) {
-			addNode(np.next());
+		try {
+			while (np.hasNext()) {
+				addNode(np.next());
+			}
+			while (ep.hasNext()) {
+				addEdge(ep.next());
+			}
+		} finally {
+			ep.close();
+			np.close();
 		}
-		while (ep.hasNext()) {
-			addEdge(ep.next());
-		}
+		return this;
 	}
+
+	/**
+	 * Build the {@link Graph}.
+	 * @return the constructed {@link Graph}.
+	 */
+	Graph build();
 }

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
@@ -69,9 +69,6 @@ public final class Neo4jGraph implements Graph {
 				service.shutdown();
 			}
 		});
-
-		// Rank the graph.
-		execute(e -> new RankCommand(rootIterator()).execute(e));
 		this.is = new SummingScoresStrategy();
 	}
 
@@ -239,5 +236,14 @@ public final class Neo4jGraph implements Graph {
 	@Override
 	public void setInterestingnessStrategy(InterestingnessStrategy is) {
 		this.is = is;
+	}
+
+	/**
+	 * Analyzes the graph by doing a pass over the entire graph in topological
+	 * order, to assign ranks and scores to nodes.
+	 */
+	public void analyze() {
+		// Rank the graph.
+		execute(e -> new RankCommand(rootIterator()).execute(e));
 	}
 }

--- a/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
+++ b/dnainator-core/src/main/java/nl/tudelft/dnainator/graph/impl/Neo4jGraph.java
@@ -242,7 +242,7 @@ public final class Neo4jGraph implements Graph {
 	 * Analyzes the graph by doing a pass over the entire graph in topological
 	 * order, to assign ranks and scores to nodes.
 	 */
-	public void analyze() {
+	protected void analyze() {
 		// Rank the graph.
 		execute(e -> new RankCommand(rootIterator()).execute(e));
 	}

--- a/dnainator-core/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jClusterTest.java
+++ b/dnainator-core/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jClusterTest.java
@@ -52,8 +52,9 @@ public class Neo4jClusterTest {
 					new BufferedReader(new InputStreamReader(nodeFile, "UTF-8")));
 			EdgeParser ep = new EdgeParserImpl(new BufferedReader(
 							new InputStreamReader(edgeFile, "UTF-8")));
-			new Neo4jBatchBuilder(DB_PATH, new AnnotationCollectionImpl()).constructGraph(np, ep);
-			db = new Neo4jGraph(DB_PATH);
+			db = (Neo4jGraph) new Neo4jBatchBuilder(DB_PATH, new AnnotationCollectionImpl())
+				.constructGraph(np, ep)
+				.build();
 		} catch (IOException | ParseException e) {
 			e.printStackTrace();
 		}

--- a/dnainator-core/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
+++ b/dnainator-core/src/test/java/nl/tudelft/dnainator/graph/impl/Neo4jGraphTest.java
@@ -62,16 +62,15 @@ public class Neo4jGraphTest {
 	public static void setUp() {
 		try {
 			FileUtils.deleteRecursively(new File(DB_PATH));
-			nodeFile = Neo4jGraphTest.class.getResourceAsStream("/strains/topo.node.graph");
-			edgeFile = Neo4jGraphTest.class.getResourceAsStream("/strains/topo.edge.graph");
-			//nodeFile = new File("10_strains_graph/simple_graph.node.graph");
-			//edgeFile = new File("10_strains_graph/simple_graph.edge.graph");
+			nodeFile = getNodeFile();
+			edgeFile = getEdgeFile();
 			NodeParser np = new NodeParserImpl(new SequenceNodeFactoryImpl(),
 					new BufferedReader(new InputStreamReader(nodeFile, "UTF-8")));
 			EdgeParser ep = new EdgeParserImpl(new BufferedReader(
 							new InputStreamReader(edgeFile, "UTF-8")));
-			new Neo4jBatchBuilder(DB_PATH, new AnnotationCollectionImpl()).constructGraph(np, ep);
-			db = new Neo4jGraph(DB_PATH);
+			db = (Neo4jGraph) new Neo4jBatchBuilder(DB_PATH, new AnnotationCollectionImpl())
+				.constructGraph(np, ep)
+				.build();
 		} catch (IOException e) {
 			fail("Couldn't initialize DB");
 		} catch (ParseException e) {
@@ -85,6 +84,14 @@ public class Neo4jGraphTest {
 		db.addAnnotation(first);
 		db.addAnnotation(middle);
 		db.addAnnotation(last);
+	}
+
+	private static InputStream getNodeFile() {
+		return Neo4jGraphTest.class.getResourceAsStream("/strains/topo.node.graph");
+	}
+
+	private static InputStream getEdgeFile() {
+		return Neo4jGraphTest.class.getResourceAsStream("/strains/topo.edge.graph");
 	}
 
 	/**
@@ -121,7 +128,7 @@ public class Neo4jGraphTest {
 		LinkedList<Integer> order = new LinkedList<>();
 		try {
 			EdgeParser ep = new EdgeParserImpl(new BufferedReader(
-							new InputStreamReader(edgeFile, "UTF-8")));
+							new InputStreamReader(getEdgeFile(), "UTF-8")));
 
 			db.execute(e -> {
 				for (Node n : new RankCommand(db.rootIterator()).topologicalOrder(e)) {

--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/services/GraphLoadService.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/services/GraphLoadService.java
@@ -7,9 +7,7 @@ import javafx.concurrent.Task;
 import nl.tudelft.dnainator.annotation.AnnotationCollection;
 import nl.tudelft.dnainator.annotation.impl.AnnotationCollectionFactoryImpl;
 import nl.tudelft.dnainator.graph.Graph;
-import nl.tudelft.dnainator.graph.GraphBuilder;
 import nl.tudelft.dnainator.graph.impl.Neo4jBatchBuilder;
-import nl.tudelft.dnainator.graph.impl.Neo4jGraph;
 import nl.tudelft.dnainator.parser.AnnotationParser;
 import nl.tudelft.dnainator.parser.EdgeParser;
 import nl.tudelft.dnainator.parser.NodeParser;
@@ -158,20 +156,12 @@ public class GraphLoadService extends Service<Graph> {
 					AnnotationParser as = new GFF3AnnotationParser(gffFilePath.get());
 					annotations = new AnnotationCollectionFactoryImpl().build(as);
 				}
-
-				GraphBuilder gb;
-				gb = new Neo4jBatchBuilder(database.get(), annotations);
-
 				EdgeParser ep = new EdgeParserImpl(getEdgeFile());
 				NodeParser np = new NodeParserImpl(getNodeFile());
-				gb.constructGraph(np, ep);
 
-				ep.close();
-				np.close();
-
-				Neo4jGraph g = new Neo4jGraph(database.get());
-				g.analyze();
-				return g;
+				return new Neo4jBatchBuilder(database.get(), annotations)
+					.constructGraph(np, ep)
+					.build();
 			}
 		};
 	}

--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/services/GraphLoadService.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/services/GraphLoadService.java
@@ -169,7 +169,9 @@ public class GraphLoadService extends Service<Graph> {
 				ep.close();
 				np.close();
 
-				return new Neo4jGraph(database.get());
+				Neo4jGraph g = new Neo4jGraph(database.get());
+				g.analyze();
+				return g;
 			}
 		};
 	}


### PR DESCRIPTION
This entails that existing databases, loaded via the welcome screen, are not ranked again. This sort of bug hasn't been visible, since it doesn't actually break anything. It just makes it slower.