### PR TITLE
[RDY] Give common nodes an identifying border.

### DIFF
--- a/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/strains/ClusterDrawable.java
+++ b/dnainator-javafx/src/main/java/nl/tudelft/dnainator/javafx/drawables/strains/ClusterDrawable.java
@@ -105,7 +105,9 @@ public class ClusterDrawable extends Group implements Drawable, Propertyable {
 		double radius = getRadius();
 
 		if (sources.size() > PIETHRESHOLD) {
-			getChildren().add(new Circle(radius));
+			Circle commonNode = new Circle(radius);
+			commonNode.getStyleClass().add("common-node");
+			getChildren().add(commonNode);
 		} else {
 			colorServer.addListener(this::onColorServerChanged);
 

--- a/dnainator-javafx/src/main/resources/style.css
+++ b/dnainator-javafx/src/main/resources/style.css
@@ -44,6 +44,11 @@
 	-fx-text-fill: #a8a8a8;
 }
 
+.common-node {
+	-fx-stroke: #a8a8a8;
+	-fx-stroke-width: .5;
+}
+
 AbstractNode {
 	-fx-font-size: 4px;
 }


### PR DESCRIPTION
Can't be done via class selectors, as `Circle`s in the `Pie`s inherit the css of the common nodes.